### PR TITLE
Two minor fixes, plus methods required to support parsing and serialization.

### DIFF
--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -158,6 +158,14 @@ impl<H> NonEmptyFrontier<H> {
     pub fn size(&self) -> usize {
         self.position.0 + 1
     }
+
+    pub fn leaf(&self) -> &Leaf<H> {
+        &self.leaf
+    }
+
+    pub fn ommers(&self) -> &Vec<H> {
+        &self.ommers
+    }
 }
 
 impl<H: Clone> NonEmptyFrontier<H> {
@@ -336,6 +344,12 @@ impl<H, const DEPTH: u8> Frontier<H, DEPTH> {
         } else {
             None
         }
+    }
+
+    /// Return the wrapped NonEmptyFrontier reference, or None if
+    /// the frontier is empty.
+    pub fn value(&self) -> Option<&NonEmptyFrontier<H>> {
+        self.frontier.as_ref()
     }
 
     /// Returns the position of latest leaf appended to the frontier,

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -106,7 +106,7 @@ impl From<usize> for Position {
 }
 
 /// A set of leaves of a Merkle tree.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Leaf<A> {
     Left(A),
     Right(A, A),
@@ -124,7 +124,7 @@ impl<A> Leaf<A> {
 /// A `[NonEmptyFrontier]` is a reduced representation of a Merkle tree,
 /// having either one or two leaf values, and then a set of hashes produced
 /// by the reduction of previously appended leaf values.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NonEmptyFrontier<H> {
     position: Position,
     leaf: Leaf<H>,
@@ -329,7 +329,7 @@ impl<H: Hashable + Clone> NonEmptyFrontier<H> {
 
 /// A possibly-empty Merkle frontier. Used when the
 /// full functionality of a Merkle bridge is not necessary.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Frontier<H, const DEPTH: u8> {
     frontier: Option<NonEmptyFrontier<H>>,
 }

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -273,7 +273,7 @@ impl<H, const DEPTH: u8> Frontier<H, DEPTH> {
         Frontier { frontier: None }
     }
 
-    /// Constructs a new non-empty frontier from is constituent parts.
+    /// Constructs a new non-empty frontier from its constituent parts.
     ///
     /// Returns `None` if the new frontier would exceed the maximum
     /// allowed depth or if the list of ommers provided is not consistent
@@ -369,7 +369,7 @@ impl<A> AuthFragment<A> {
     }
 
     /// Construct a fragment from its component parts. This cannot
-    /// not perform any meaningful validation that the provided values
+    /// perform any meaningful validation that the provided values
     /// are valid.
     pub fn from_parts(position: Position, altitudes_observed: usize, values: Vec<A>) -> Self {
         assert!(altitudes_observed <= values.len());

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -61,7 +61,7 @@ impl Position {
     /// an authentication path to the root of a merkle tree that has `self + 1`
     /// nodes.
     pub fn altitudes_required(&self) -> impl Iterator<Item = Altitude> + '_ {
-        (0..=(self.max_altitude() + 1).0)
+        (0..=self.max_altitude().0)
             .into_iter()
             .filter_map(move |i| {
                 if self.0 == 0 || self.0 & (1 << i) == 0 {

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -694,6 +694,35 @@ pub enum BridgeTreeError {
     CheckpointMismatch,
 }
 
+impl<H: Hash + Eq, const DEPTH: u8> BridgeTree<H, DEPTH> {
+    /// Removes the oldest checkpoint. Returns true if successful and false if
+    /// there are no checkpoints.
+    fn drop_oldest_checkpoint(&mut self) -> bool {
+        if self.checkpoints.is_empty() {
+            false
+        } else {
+            self.checkpoints.remove(0);
+            true
+        }
+    }
+
+    pub fn bridges(&self) -> &Vec<MerkleBridge<H>> {
+        &self.bridges
+    }
+
+    pub fn witnessable_leaves(&self) -> &HashMap<H, usize> {
+        &self.saved
+    }
+
+    pub fn checkpoints(&self) -> &Vec<Checkpoint<H>> {
+        &self.checkpoints
+    }
+
+    pub fn max_checkpoints(&self) -> usize {
+        self.max_checkpoints
+    }
+}
+
 impl<H: Hashable + Hash + Eq + Clone, const DEPTH: u8> BridgeTree<H, DEPTH> {
     pub fn new(max_checkpoints: usize) -> Self {
         BridgeTree {
@@ -754,33 +783,6 @@ impl<H: Hashable + Hash + Eq + Clone, const DEPTH: u8> BridgeTree<H, DEPTH> {
                 max_checkpoints,
             })
         }
-    }
-
-    /// Removes the oldest checkpoint. Returns true if successful and false if
-    /// there are no checkpoints.
-    fn drop_oldest_checkpoint(&mut self) -> bool {
-        if self.checkpoints.is_empty() {
-            false
-        } else {
-            self.checkpoints.remove(0);
-            true
-        }
-    }
-
-    pub fn bridges(&self) -> &Vec<MerkleBridge<H>> {
-        &self.bridges
-    }
-
-    pub fn witnessable_leaves(&self) -> &HashMap<H, usize> {
-        &self.saved
-    }
-
-    pub fn checkpoints(&self) -> &Vec<Checkpoint<H>> {
-        &self.checkpoints
-    }
-
-    pub fn max_checkpoints(&self) -> usize {
-        self.max_checkpoints
     }
 }
 

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -99,6 +99,12 @@ impl From<Position> for usize {
     }
 }
 
+impl From<usize> for Position {
+    fn from(sz: usize) -> Self {
+        Position(sz)
+    }
+}
+
 /// A set of leaves of a Merkle tree.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Leaf<A> {

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -112,6 +112,15 @@ pub enum Leaf<A> {
     Right(A, A),
 }
 
+impl<A> Leaf<A> {
+    pub fn into_value(self) -> A {
+        match self {
+            Leaf::Left(a) => a,
+            Leaf::Right(_, a) => a,
+        }
+    }
+}
+
 /// A `[NonEmptyFrontier]` is a reduced representation of a Merkle tree,
 /// having either one or two leaf values, and then a set of hashes produced
 /// by the reduction of previously appended leaf values.

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -83,14 +83,16 @@ impl<H> NonEmptyFrontier<H> {
 
     /// Returns the number of leaves that have been appended to this frontier.
     pub fn size(&self) -> usize {
-        <usize>::try_from(self.position).expect("The number of leaves must not exceed the representable range of a `usize`") + 1
+        <usize>::try_from(self.position)
+            .expect("The number of leaves must not exceed the representable range of a `usize`")
+            + 1
     }
 
     pub fn leaf(&self) -> &Leaf<H> {
         &self.leaf
     }
 
-    pub fn ommers(&self) -> &Vec<H> {
+    pub fn ommers(&self) -> &[H] {
         &self.ommers
     }
 }
@@ -281,15 +283,7 @@ impl<H, const DEPTH: u8> Frontier<H, DEPTH> {
         leaf: Leaf<H>,
         ommers: Vec<H>,
     ) -> Result<Self, FrontierError> {
-        if position.max_altitude().0 <= DEPTH {
-            NonEmptyFrontier::from_parts(position, leaf, ommers).map(|frontier| Frontier {
-                frontier: Some(frontier),
-            })
-        } else {
-            Err(FrontierError::MaxDepthExceeded {
-                altitude: position.max_altitude(),
-            })
-        }
+        NonEmptyFrontier::from_parts(position, leaf, ommers).and_then(Self::try_from)
     }
 
     /// Return the wrapped NonEmptyFrontier reference, or None if
@@ -404,7 +398,7 @@ impl<A> AuthFragment<A> {
         self.altitudes_observed
     }
 
-    pub fn values(&self) -> &Vec<A> {
+    pub fn values(&self) -> &[A] {
         &self.values
     }
 
@@ -639,7 +633,7 @@ impl<H: Hash + Eq, const DEPTH: u8> BridgeTree<H, DEPTH> {
         }
     }
 
-    pub fn bridges(&self) -> &Vec<MerkleBridge<H>> {
+    pub fn bridges(&self) -> &[MerkleBridge<H>] {
         &self.bridges
     }
 
@@ -647,7 +641,7 @@ impl<H: Hash + Eq, const DEPTH: u8> BridgeTree<H, DEPTH> {
         &self.saved
     }
 
-    pub fn checkpoints(&self) -> &Vec<Checkpoint<H>> {
+    pub fn checkpoints(&self) -> &[Checkpoint<H>] {
         &self.checkpoints
     }
 
@@ -1084,7 +1078,7 @@ mod tests {
         assert_eq!(
             tree.authentication_path(&"c".to_string()),
             Some((
-                <Position>::from(2),
+                Position::from(2),
                 vec![
                     "_".to_string(),
                     "ab".to_string(),
@@ -1098,7 +1092,7 @@ mod tests {
         assert_eq!(
             tree.authentication_path(&"c".to_string()),
             Some((
-                <Position>::from(2),
+                Position::from(2),
                 vec![
                     "d".to_string(),
                     "ab".to_string(),
@@ -1112,7 +1106,7 @@ mod tests {
         assert_eq!(
             tree.authentication_path(&"c".to_string()),
             Some((
-                <Position>::from(2),
+                Position::from(2),
                 vec![
                     "d".to_string(),
                     "ab".to_string(),
@@ -1160,7 +1154,7 @@ mod tests {
         assert_eq!(
             tree.authentication_path(&"f".to_string()),
             Some((
-                <Position>::from(5),
+                Position::from(5),
                 vec![
                     "e".to_string(),
                     "g_".to_string(),
@@ -1180,7 +1174,7 @@ mod tests {
         assert_eq!(
             tree.authentication_path(&"k".to_string()),
             Some((
-                <Position>::from(10),
+                Position::from(10),
                 vec![
                     "l".to_string(),
                     "ij".to_string(),
@@ -1256,7 +1250,7 @@ mod tests {
         assert_eq!(
             tree.authentication_path(&"c".to_string()),
             Some((
-                <Position>::from(2),
+                Position::from(2),
                 vec![
                     "d".to_string(),
                     "ab".to_string(),
@@ -1279,7 +1273,7 @@ mod tests {
         assert_eq!(
             tree.authentication_path(&"m".to_string()),
             Some((
-                <Position>::from(12),
+                Position::from(12),
                 vec![
                     "n".to_string(),
                     "op".to_string(),
@@ -1302,7 +1296,7 @@ mod tests {
         assert_eq!(
             Operation::apply_all(&ops, &mut tree),
             Some((
-                <Position>::from(11),
+                Position::from(11),
                 vec![
                     "k".to_string(),
                     "ij".to_string(),

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,5 +1,5 @@
 /// Sample implementation of the Tree interface.
-use super::{Altitude, Frontier, Hashable, Recording, Tree};
+use super::{Altitude, Frontier, Hashable, Position, Recording, Tree};
 
 #[derive(Clone)]
 pub struct CompleteTree<H: Hashable> {
@@ -78,7 +78,7 @@ impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
     /// Obtains an authentication path to the value specified in the tree.
     /// Returns `None` if there is no available authentication path to the
     /// specified value.
-    fn authentication_path(&self, value: &H) -> Option<(usize, Vec<H>)> {
+    fn authentication_path(&self, value: &H) -> Option<(Position, Vec<H>)> {
         self.witnesses
             .iter()
             .find(|witness| witness.1 == *value)
@@ -92,7 +92,7 @@ impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
                     index &= usize::MAX << (bit + 1);
                 }
 
-                (pos, path)
+                (pos.into(), path)
             })
     }
 


### PR DESCRIPTION
Two fixes are included here:
* Fix an off-by-one error in the computation of the maximum altitude of the frontier. This did not cause a divergence from correct authentication path computation because the maximum depth of the tree was checked separately from the generation of the list of required path components.
* Ensure that AuthFragment::fuse validates the compatibility of successive fragments being appended to one another. While in practice fragments should never be concatenated out of order, this was not previously being checked.