### PR TITLE
Change the checkpointing semantics fully restore pre-checkpoint state.

### DIFF
--- a/src/sample.rs
+++ b/src/sample.rs
@@ -312,4 +312,26 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn rewind_remove_witness() {
+        const DEPTH: usize = 3;
+        let mut tree = CompleteTree::<String>::new(DEPTH, 100);
+        tree.append(&"e".to_string());
+        tree.witness();
+        tree.checkpoint();
+        tree.remove_witness(&"e".to_string());
+        tree.rewind();
+        tree.append(&"g".to_string());
+        assert_eq!(tree.remove_witness(&"e".to_string()), true);
+
+        let mut tree = CompleteTree::<String>::new(DEPTH, 100);
+        tree.append(&"e".to_string());
+        tree.witness();
+        tree.remove_witness(&"e".to_string());
+        tree.checkpoint();
+        tree.rewind();
+        tree.append(&"g".to_string());
+        assert_eq!(tree.remove_witness(&"e".to_string()), false);
+    }
 }


### PR DESCRIPTION
Prior to this change, some combinations of checkpointing, witnessing, and rewinding did not return the sample tree to the state that it existed in prior to the checkpoint. These inconsistencies added corner cases that increase implementation complexity and make operations on the tree harder to reason about.