### PR TITLE
Use (position, hash) pair to uniquely identify leaves.

### DIFF
--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -1212,7 +1212,7 @@ mod tests {
         let mut t = BridgeTree::<String, 7>::new(10);
         let mut to_unwitness = vec![];
         let mut has_auth_path = vec![];
-        for i in 0u32..100 {
+        for i in 0usize..100 {
             let elem: String = format!("{},", i);
             assert_eq!(t.append(&elem), true);
             if i % 5 == 0 {
@@ -1221,21 +1221,22 @@ mod tests {
             if i % 7 == 0 {
                 t.witness();
                 if i > 0 && i % 2 == 0 {
-                    to_unwitness.push(elem);
+                    to_unwitness.push((Position::from(i), elem));
                 } else {
-                    has_auth_path.push(elem);
+                    has_auth_path.push((Position::from(i), elem));
                 }
             }
             if i % 11 == 0 && !to_unwitness.is_empty() {
-                t.remove_witness(&to_unwitness.remove(0));
+                let (pos, elem) = to_unwitness.remove(0);
+                t.remove_witness(pos, &elem);
             }
         }
         // 33 = 1 (root) + 20 (checkpointed) + 14 (witnessed) - 2 (witnessed & checkpointed)
         assert_eq!(t.bridges().len(), 1 + 20 + 14 - 2);
         let auth_paths = has_auth_path
             .iter()
-            .map(|elem| {
-                t.authentication_path(elem)
+            .map(|(pos, elem)| {
+                t.authentication_path(*pos, &elem)
                     .expect("Must be able to get auth path")
             })
             .collect::<Vec<_>>();
@@ -1244,8 +1245,8 @@ mod tests {
         assert_eq!(t.bridges().len(), 33 - 10 + 1 - 3);
         let retained_auth_paths = has_auth_path
             .iter()
-            .map(|elem| {
-                t.authentication_path(elem)
+            .map(|(pos, elem)| {
+                t.authentication_path(*pos, &elem)
                     .expect("Must be able to get auth path")
             })
             .collect::<Vec<_>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub mod bridgetree;
 mod sample;
 
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use std::num::TryFromIntError;
 use std::ops::{Add, AddAssign, Sub};
 
 /// A type-safe wrapper for indexing into "levels" of a binary tree, such that
@@ -193,6 +195,13 @@ impl From<usize> for Position {
     }
 }
 
+impl TryFrom<u64> for Position {
+    type Error = TryFromIntError;
+    fn try_from(sz: u64) -> Result<Self, Self::Error> {
+        <usize>::try_from(sz).map(Self)
+    }
+}
+
 /// A trait describing the operations that make a value  suitable for inclusion in
 /// an incremental merkle tree.
 pub trait Hashable: Sized + Ord + Clone {
@@ -290,7 +299,6 @@ pub trait Recording<H> {
 #[cfg(test)]
 pub(crate) mod tests {
     #![allow(deprecated)]
-    use std::convert::TryFrom;
     use std::fmt::Debug;
     use std::hash::Hasher;
     use std::hash::SipHasher;
@@ -376,73 +384,58 @@ pub(crate) mod tests {
         tree.append(&"a".to_string());
         tree.witness();
         assert_eq!(
-            tree.authentication_path(&"a".to_string()),
-            Some((
-                Position::zero(),
-                vec![
-                    "_".to_string(),
-                    "__".to_string(),
-                    "____".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::from(0), &"a".to_string()),
+            Some(vec![
+                "_".to_string(),
+                "__".to_string(),
+                "____".to_string(),
+                "________".to_string()
+            ])
         );
 
         tree.append(&"b".to_string());
         assert_eq!(
-            tree.authentication_path(&"a".to_string()),
-            Some((
-                Position::zero(),
-                vec![
-                    "b".to_string(),
-                    "__".to_string(),
-                    "____".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::zero(), &"a".to_string()),
+            Some(vec![
+                "b".to_string(),
+                "__".to_string(),
+                "____".to_string(),
+                "________".to_string()
+            ])
         );
 
         tree.append(&"c".to_string());
         tree.witness();
         assert_eq!(
-            tree.authentication_path(&"c".to_string()),
-            Some((
-                Position::from(2),
-                vec![
-                    "_".to_string(),
-                    "ab".to_string(),
-                    "____".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::from(2), &"c".to_string()),
+            Some(vec![
+                "_".to_string(),
+                "ab".to_string(),
+                "____".to_string(),
+                "________".to_string()
+            ])
         );
 
         tree.append(&"d".to_string());
         assert_eq!(
-            tree.authentication_path(&"c".to_string()),
-            Some((
-                Position::from(2),
-                vec![
-                    "d".to_string(),
-                    "ab".to_string(),
-                    "____".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::from(2), &"c".to_string()),
+            Some(vec![
+                "d".to_string(),
+                "ab".to_string(),
+                "____".to_string(),
+                "________".to_string()
+            ])
         );
 
         tree.append(&"e".to_string());
         assert_eq!(
-            tree.authentication_path(&"c".to_string()),
-            Some((
-                Position::from(2),
-                vec![
-                    "d".to_string(),
-                    "ab".to_string(),
-                    "e___".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::from(2), &"c".to_string()),
+            Some(vec![
+                "d".to_string(),
+                "ab".to_string(),
+                "e___".to_string(),
+                "________".to_string()
+            ])
         );
 
         let mut tree = new_tree(100);
@@ -455,16 +448,13 @@ pub(crate) mod tests {
         tree.append(&"h".to_string());
 
         assert_eq!(
-            tree.authentication_path(&"a".to_string()),
-            Some((
-                Position::zero(),
-                vec![
-                    "b".to_string(),
-                    "cd".to_string(),
-                    "efgh".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::zero(), &"a".to_string()),
+            Some(vec![
+                "b".to_string(),
+                "cd".to_string(),
+                "efgh".to_string(),
+                "________".to_string()
+            ])
         );
 
         let mut tree = new_tree(100);
@@ -481,16 +471,13 @@ pub(crate) mod tests {
         tree.append(&"g".to_string());
 
         assert_eq!(
-            tree.authentication_path(&"f".to_string()),
-            Some((
-                Position::from(5),
-                vec![
-                    "e".to_string(),
-                    "g_".to_string(),
-                    "abcd".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::from(5), &"f".to_string()),
+            Some(vec![
+                "e".to_string(),
+                "g_".to_string(),
+                "abcd".to_string(),
+                "________".to_string()
+            ])
         );
 
         let mut tree = new_tree(100);
@@ -501,16 +488,13 @@ pub(crate) mod tests {
         tree.append(&'l'.to_string());
 
         assert_eq!(
-            tree.authentication_path(&"k".to_string()),
-            Some((
-                Position::from(10),
-                vec![
-                    "l".to_string(),
-                    "ij".to_string(),
-                    "____".to_string(),
-                    "abcdefgh".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::from(10), &"k".to_string()),
+            Some(vec![
+                "l".to_string(),
+                "ij".to_string(),
+                "____".to_string(),
+                "abcdefgh".to_string()
+            ])
         );
 
         let mut tree = new_tree(100);
@@ -527,16 +511,13 @@ pub(crate) mod tests {
         }
 
         assert_eq!(
-            tree.authentication_path(&"a".to_string()),
-            Some((
-                Position::zero(),
-                vec![
-                    "b".to_string(),
-                    "cd".to_string(),
-                    "efgh".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::zero(), &"a".to_string()),
+            Some(vec![
+                "b".to_string(),
+                "cd".to_string(),
+                "efgh".to_string(),
+                "________".to_string()
+            ])
         );
 
         let mut tree = new_tree(100);
@@ -554,16 +535,22 @@ pub(crate) mod tests {
         assert_eq!(tree.rewind(), true);
 
         assert_eq!(
-            tree.authentication_path(&"c".to_string()),
-            Some((
-                Position::from(2),
-                vec![
-                    "d".to_string(),
-                    "ab".to_string(),
-                    "efg_".to_string(),
-                    "________".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::from(2), &"c".to_string()),
+            Some(vec![
+                "d".to_string(),
+                "ab".to_string(),
+                "efg_".to_string(),
+                "________".to_string()
+            ])
+        );
+
+        let mut tree = new_tree(100);
+        tree.append(&'a'.to_string());
+        tree.append(&'b'.to_string());
+        tree.witness();
+        assert_eq!(
+            tree.authentication_path(Position::from(0), &"b".to_string()),
+            None
         );
 
         let mut tree = new_tree(100);
@@ -577,16 +564,13 @@ pub(crate) mod tests {
         tree.append(&'p'.to_string());
 
         assert_eq!(
-            tree.authentication_path(&"m".to_string()),
-            Some((
-                Position::from(12),
-                vec![
-                    "n".to_string(),
-                    "op".to_string(),
-                    "ijkl".to_string(),
-                    "abcdefgh".to_string()
-                ]
-            ))
+            tree.authentication_path(Position::from(12), &"m".to_string()),
+            Some(vec![
+                "n".to_string(),
+                "op".to_string(),
+                "ijkl".to_string(),
+                "abcdefgh".to_string()
+            ])
         );
 
         let ops = ('a'..='l')
@@ -595,7 +579,7 @@ pub(crate) mod tests {
             .chain(Some(Witness))
             .chain(Some(Append('m'.to_string())))
             .chain(Some(Append('n'.to_string())))
-            .chain(Some(Authpath('l'.to_string())))
+            .chain(Some(Authpath(11usize.into(), 'l'.to_string())))
             .collect::<Vec<_>>();
 
         let mut tree = new_tree(100);
@@ -656,21 +640,21 @@ pub(crate) mod tests {
         tree.append(&"e".to_string());
         tree.witness();
         tree.checkpoint();
-        assert_eq!(tree.remove_witness(&"e".to_string()), true);
+        assert_eq!(tree.remove_witness(0usize.into(), &"e".to_string()), true);
         assert_eq!(tree.rewind(), true);
-        assert_eq!(tree.remove_witness(&"e".to_string()), true);
+        assert_eq!(tree.remove_witness(0usize.into(), &"e".to_string()), true);
 
         let mut tree = new_tree(100);
         tree.append(&"e".to_string());
         tree.witness();
-        assert_eq!(tree.remove_witness(&"e".to_string()), true);
+        assert_eq!(tree.remove_witness(0usize.into(), &"e".to_string()), true);
         tree.checkpoint();
         assert_eq!(tree.rewind(), true);
-        assert_eq!(tree.remove_witness(&"e".to_string()), false);
+        assert_eq!(tree.remove_witness(0usize.into(), &"e".to_string()), false);
 
         let mut tree = new_tree(100);
         tree.append(&"a".to_string());
-        assert_eq!(tree.remove_witness(&"a".to_string()), false);
+        assert_eq!(tree.remove_witness(0usize.into(), &"a".to_string()), false);
         tree.checkpoint();
         assert_eq!(tree.witness(), true);
         assert_eq!(tree.rewind(), false);
@@ -679,9 +663,9 @@ pub(crate) mod tests {
         tree.append(&"a".to_string());
         tree.checkpoint();
         assert_eq!(tree.witness(), true);
-        assert_eq!(tree.remove_witness(&"a".to_string()), true);
+        assert_eq!(tree.remove_witness(0usize.into(), &"a".to_string()), true);
         assert_eq!(tree.rewind(), true);
-        assert_eq!(tree.remove_witness(&"a".to_string()), false);
+        assert_eq!(tree.remove_witness(0usize.into(), &"a".to_string()), false);
 
         // The following check_operations tests cover errors where the
         // test framework itself previously did not correctly handle
@@ -689,7 +673,7 @@ pub(crate) mod tests {
 
         let ops = vec![
             Append("a".to_string()),
-            Unwitness("a".to_string()),
+            Unwitness(0usize.into(), "a".to_string()),
             Checkpoint,
             Witness,
             Rewind,
@@ -702,9 +686,9 @@ pub(crate) mod tests {
             Witness,
             Append("m".to_string()),
             Checkpoint,
-            Unwitness("s".to_string()),
+            Unwitness(0usize.into(), "s".to_string()),
             Rewind,
-            Unwitness("s".to_string()),
+            Unwitness(0usize.into(), "s".to_string()),
         ];
         let result = check_operations(ops);
         assert!(matches!(result, Ok(())), "Test failed: {:?}", result);
@@ -713,9 +697,9 @@ pub(crate) mod tests {
             Append("d".to_string()),
             Checkpoint,
             Witness,
-            Unwitness("d".to_string()),
+            Unwitness(0usize.into(), "d".to_string()),
             Rewind,
-            Unwitness("d".to_string()),
+            Unwitness(0usize.into(), "d".to_string()),
         ];
         let result = check_operations(ops);
         assert!(matches!(result, Ok(())), "Test failed: {:?}", result);
@@ -725,7 +709,7 @@ pub(crate) mod tests {
             Checkpoint,
             Witness,
             Checkpoint,
-            Unwitness("o".to_string()),
+            Unwitness(0usize.into(), "o".to_string()),
             Rewind,
             Rewind,
         ];
@@ -773,7 +757,15 @@ pub(crate) mod tests {
         type Recording = CombinedRecording<H, DEPTH>;
 
         /// Returns the most recently appended leaf value.
-        fn current_leaf(&self) -> Option<&H> {
+        fn current_position(&self) -> Option<Position> {
+            let a = self.inefficient.current_position();
+            let b = self.efficient.current_position();
+            assert_eq!(a, b);
+            a
+        }
+
+        /// Returns the most recently appended leaf value and its position in the tree.
+        fn current_leaf(&self) -> Option<(Position, H)> {
             let a = self.inefficient.current_leaf();
             let b = self.efficient.current_leaf();
             assert_eq!(a, b);
@@ -781,10 +773,10 @@ pub(crate) mod tests {
         }
 
         /// Returns `true` if the tree can produce an authentication path for
-        /// the specified leaf value.
-        fn is_witnessed(&self, value: &H) -> bool {
-            let a = self.inefficient.is_witnessed(value);
-            let b = self.efficient.is_witnessed(value);
+        /// the specified leaf value from the specified position in the tree.
+        fn is_witnessed(&self, position: Position, value: &H) -> bool {
+            let a = self.inefficient.is_witnessed(position, value);
+            let b = self.efficient.is_witnessed(position, value);
             assert_eq!(a, b);
             a
         }
@@ -801,9 +793,9 @@ pub(crate) mod tests {
         /// Obtains an authentication path to the value specified in the tree.
         /// Returns `None` if there is no available authentication path to the
         /// specified value.
-        fn authentication_path(&self, value: &H) -> Option<(Position, Vec<H>)> {
-            let a = self.inefficient.authentication_path(value);
-            let b = self.efficient.authentication_path(value);
+        fn authentication_path(&self, position: Position, value: &H) -> Option<Vec<H>> {
+            let a = self.inefficient.authentication_path(position, value);
+            let b = self.efficient.authentication_path(position, value);
             assert_eq!(a, b);
             a
         }
@@ -811,9 +803,9 @@ pub(crate) mod tests {
         /// Marks the specified tree state value as a value we're no longer
         /// interested in maintaining a witness for. Returns true if successful and
         /// false if the value is not a known witness.
-        fn remove_witness(&mut self, value: &H) -> bool {
-            let a = self.inefficient.remove_witness(value);
-            let b = self.efficient.remove_witness(value);
+        fn remove_witness(&mut self, position: Position, value: &H) -> bool {
+            let a = self.inefficient.remove_witness(position, value);
+            let b = self.efficient.remove_witness(position, value);
             assert_eq!(a, b);
             a
         }
@@ -879,10 +871,10 @@ pub(crate) mod tests {
     pub enum Operation<A> {
         Append(A),
         Witness,
-        Unwitness(A),
+        Unwitness(Position, A),
         Checkpoint,
         Rewind,
-        Authpath(A),
+        Authpath(Position, A),
     }
 
     use Operation::*;
@@ -898,8 +890,8 @@ pub(crate) mod tests {
                     assert!(tree.witness(), "witness failed");
                     None
                 }
-                Unwitness(a) => {
-                    assert!(tree.remove_witness(a), "remove witness failed");
+                Unwitness(p, a) => {
+                    assert!(tree.remove_witness(*p, a), "remove witness failed");
                     None
                 }
                 Checkpoint => {
@@ -910,7 +902,7 @@ pub(crate) mod tests {
                     assert!(tree.rewind(), "rewind failed");
                     None
                 }
-                Authpath(a) => tree.authentication_path(a),
+                Authpath(p, a) => tree.authentication_path(*p, a).map(|xs| (*p, xs)),
             }
         }
 
@@ -936,7 +928,7 @@ pub(crate) mod tests {
         for (i, v) in path
             .iter()
             .enumerate()
-            .map(|(i, v)| (((<usize>::try_from(position).unwrap() >> i) & 1) == 1, v))
+            .map(|(i, v)| (((<usize>::from(position) >> i) & 1) == 1, v))
         {
             if i {
                 cur = H::combine(lvl, v, &cur);
@@ -1000,25 +992,90 @@ pub(crate) mod tests {
     }
 
     use proptest::prelude::*;
-    use proptest::sample::select;
+    use proptest::sample::{select, SizeRange};
 
-    fn arb_operation<G: Strategy>(item_gen: G) -> impl Strategy<Value = Operation<G::Value>>
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum OpType {
+        Append,
+        Witness,
+        Unwitness,
+        Checkpoint,
+        Rewind,
+        Authpath,
+    }
+
+    fn arb_operations_0<H: Clone + Debug + 'static>(
+        optypes: Vec<OpType>,
+        items: Vec<H>,
+    ) -> impl Strategy<Value = Vec<Operation<H>>> {
+        let mut idx = 0;
+        optypes
+            .iter()
+            .map(move |t| {
+                let items = items.clone();
+                match t {
+                    OpType::Append => {
+                        let item = items.get(idx).unwrap().clone();
+                        idx += 1;
+                        Just(Append(item)).boxed()
+                    }
+                    OpType::Witness => Just(Witness).boxed(),
+                    OpType::Unwitness => (0..(idx + 1))
+                        .prop_map(move |i| {
+                            let item = items.get(i).unwrap().clone();
+                            Unwitness(Position::from(i), item)
+                        })
+                        .boxed(),
+                    OpType::Checkpoint => Just(Checkpoint).boxed(),
+                    OpType::Rewind => Just(Rewind).boxed(),
+                    OpType::Authpath => (0..(idx + 1))
+                        .prop_map(move |i| {
+                            let item = items.get(i).unwrap().clone();
+                            Authpath(Position::from(i), item)
+                        })
+                        .boxed(),
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+
+    fn arb_operations_1<G: Strategy>(
+        item_gen: G,
+        optypes: Vec<OpType>,
+    ) -> impl Strategy<Value = Vec<Operation<G::Value>>>
     where
         G::Value: Clone + 'static,
     {
-        item_gen.prop_flat_map(|item| {
-            select(vec![
-                Append(item.clone()),
-                Witness,
-                Unwitness(item.clone()),
-                Checkpoint,
-                Rewind,
-                Authpath(item),
-            ])
-        })
+        let append_count = optypes
+            .iter()
+            .filter(|t| matches!(t, OpType::Append))
+            .count();
+        proptest::collection::vec(item_gen, append_count + 1)
+            .prop_flat_map(move |items: Vec<G::Value>| arb_operations_0(optypes.clone(), items))
     }
 
-    fn check_operations<H: Hashable + std::fmt::Debug + Eq + Ord>(
+    fn arb_operations<G: Strategy + Clone>(
+        item_gen: G,
+        count: impl Into<SizeRange>,
+    ) -> impl Strategy<Value = Vec<Operation<G::Value>>>
+    where
+        G::Value: Clone + 'static,
+    {
+        proptest::collection::vec(
+            select(vec![
+                OpType::Append,
+                OpType::Witness,
+                OpType::Unwitness,
+                OpType::Checkpoint,
+                OpType::Rewind,
+                OpType::Authpath,
+            ]),
+            count,
+        )
+        .prop_flat_map(move |optypes: Vec<OpType>| arb_operations_1(item_gen.clone(), optypes))
+    }
+
+    fn check_operations<H: Hashable + std::fmt::Debug>(
         ops: Vec<Operation<H>>,
     ) -> Result<(), TestCaseError> {
         const DEPTH: u8 = 4;
@@ -1055,8 +1112,8 @@ pub(crate) mod tests {
                         prop_assert_eq!(tree_size, 0);
                     }
                 }
-                Unwitness(value) => {
-                    tree.remove_witness(&value);
+                Unwitness(position, value) => {
+                    tree.remove_witness(position, &value);
                 }
                 Checkpoint => {
                     tree_checkpoints.push(tree_size);
@@ -1072,8 +1129,8 @@ pub(crate) mod tests {
                         tree_size = checkpointed_tree_size;
                     }
                 }
-                Authpath(value) => {
-                    if let Some((position, path)) = tree.authentication_path(&value) {
+                Authpath(position, value) => {
+                    if let Some(path) = tree.authentication_path(position, &value) {
                         let mut extended_tree_values = tree_values.clone();
                         extended_tree_values.resize(1 << DEPTH, H::empty_leaf());
                         let expected_root = lazy_root::<H>(extended_tree_values);
@@ -1103,20 +1160,14 @@ pub(crate) mod tests {
 
         #[test]
         fn check_randomized_u64_ops(
-            ops in proptest::collection::vec(
-                arb_operation((0..32u64).prop_map(SipHashable)),
-                1..100
-            )
+            ops in arb_operations((0..32u64).prop_map(SipHashable), 1..100)
         ) {
             check_operations(ops)?;
         }
 
         #[test]
         fn check_randomized_str_ops(
-            ops in proptest::collection::vec(
-                arb_operation((97u8..123).prop_map(|c| char::from(c).to_string())),
-                1..100
-            )
+            ops in arb_operations((97u8..123).prop_map(|c| char::from(c).to_string()), 1..100)
         ) {
             check_operations::<String>(ops)?;
         }

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -339,7 +339,8 @@ pub(crate) fn lazy_root<H: Hashable + Clone>(mut leaves: Vec<H>) -> H {
 #[cfg(test)]
 mod tests {
     use crate::tests::{compute_root_from_auth_path, SipHashable};
-    use crate::{Altitude, Frontier, Hashable, Tree};
+    use crate::{Altitude, Frontier, Hashable, Position, Tree};
+    use std::convert::TryFrom;
 
     use super::CompleteTree;
 
@@ -421,8 +422,9 @@ mod tests {
 
         assert_eq!(tree.root(), expected);
 
-        for i in 0..(1 << DEPTH) {
-            let (position, path) = tree.authentication_path(&SipHashable(i)).unwrap();
+        for i in 0u64..(1 << DEPTH) {
+            let position = Position::try_from(i).unwrap();
+            let path = tree.authentication_path(position, &SipHashable(i)).unwrap();
             assert_eq!(
                 compute_root_from_auth_path(SipHashable(i), position, &path),
                 expected

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,11 +1,12 @@
-/// Sample implementation of the Tree interface.
 use super::{Altitude, Frontier, Hashable, Position, Recording, Tree};
+/// Sample implementation of the Tree interface.
+use std::convert::TryInto;
 
 #[derive(Clone, Debug)]
 pub struct TreeState<H: Hashable> {
     leaves: Vec<H>,
     current_offset: usize,
-    witnesses: Vec<(usize, H)>,
+    witnesses: Vec<(Position, H)>,
     depth: usize,
 }
 
@@ -42,27 +43,34 @@ impl<H: Hashable + Clone> Frontier<H> for TreeState<H> {
 }
 
 impl<H: Hashable + PartialEq + Clone> TreeState<H> {
-    /// Returns the leaf most recently appended to the tree
-    fn current_leaf(&self) -> Option<&H> {
+    fn current_position(&self) -> Option<Position> {
         if self.current_offset == 0 {
             None
         } else {
-            Some(&self.leaves[self.current_offset - 1])
+            Some((self.current_offset - 1).into())
         }
     }
 
-    /// Returns whether a leaf with the specified value has been witnessed
-    fn is_witnessed(&self, value: &H) -> bool {
-        self.witnesses.iter().any(|(_, v)| v == value)
+    /// Returns the leaf most recently appended to the tree
+    fn current_leaf(&self) -> Option<(Position, H)> {
+        self.current_position()
+            .map(|p| (p, self.leaves[<usize>::from(p)].clone()))
+    }
+
+    /// Returns whether a leaf with the specified position and value has been witnessed
+    fn is_witnessed(&self, position: Position, value: &H) -> bool {
+        self.witnesses
+            .iter()
+            .any(|(pos, v)| pos == &position && v == value)
     }
 
     /// Marks the current tree state leaf as a value that we're interested in
     /// witnessing. Returns true if successful and false if the tree is empty.
     fn witness(&mut self) -> bool {
-        if let Some(value) = self.current_leaf() {
-            if !self.is_witnessed(value) {
+        if let Some((pos, value)) = self.current_leaf() {
+            if !self.is_witnessed(pos, &value) {
                 let value = value.clone();
-                self.witnesses.push((self.current_offset - 1, value));
+                self.witnesses.push((pos, value));
             }
             true
         } else {
@@ -73,36 +81,37 @@ impl<H: Hashable + PartialEq + Clone> TreeState<H> {
     /// Obtains an authentication path to the value specified in the tree.
     /// Returns `None` if there is no available authentication path to the
     /// specified value.
-    fn authentication_path(&self, value: &H) -> Option<(Position, Vec<H>)> {
+    fn authentication_path(&self, position: Position, value: &H) -> Option<Vec<H>> {
         self.witnesses
             .iter()
-            .find(|witness| witness.1 == *value)
-            .map(|&(pos, _)| {
+            .find(|(pos, v)| pos == &position && v == value)
+            .map(|_| {
                 let mut path = vec![];
 
-                let mut index = pos;
+                let mut leaf_idx: usize = position.into();
                 for bit in 0..self.depth {
-                    index ^= 1 << bit;
-                    path.push(lazy_root::<H>(self.leaves[index..][0..(1 << bit)].to_vec()));
-                    index &= usize::MAX << (bit + 1);
+                    leaf_idx ^= 1 << bit;
+                    path.push(lazy_root::<H>(
+                        self.leaves[leaf_idx..][0..(1 << bit)].to_vec(),
+                    ));
+                    leaf_idx &= usize::MAX << (bit + 1);
                 }
 
-                (pos.into(), path)
+                path
             })
     }
 
     /// Marks the specified tree state value as a value we're no longer
     /// interested in maintaining a witness for. Returns true if successful and
     /// false if the value is not a known witness.
-    fn remove_witness(&mut self, value: &H) -> bool {
-        if let Some((position, _)) = self
+    fn remove_witness(&mut self, position: Position, value: &H) -> bool {
+        if let Some((witness_index, _)) = self
             .witnesses
             .iter()
             .enumerate()
-            .find(|witness| (witness.1).1 == *value)
+            .find(|(_i, (pos, v))| pos == &position && v == value)
         {
-            self.witnesses.remove(position);
-
+            self.witnesses.remove(witness_index);
             true
         } else {
             false
@@ -182,14 +191,19 @@ impl<H: Hashable + PartialEq + Clone> CompleteTree<H> {
 impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
     type Recording = CompleteRecording<H>;
 
+    /// Returns the most recently appended leaf value.
+    fn current_position(&self) -> Option<Position> {
+        self.tree_state.current_position()
+    }
+
     /// Returns the leaf most recently appended to the tree
-    fn current_leaf(&self) -> Option<&H> {
+    fn current_leaf(&self) -> Option<(Position, H)> {
         self.tree_state.current_leaf()
     }
 
     /// Returns whether a leaf with the specified value has been witnessed
-    fn is_witnessed(&self, value: &H) -> bool {
-        self.tree_state.is_witnessed(value)
+    fn is_witnessed(&self, position: Position, value: &H) -> bool {
+        self.tree_state.is_witnessed(position, value)
     }
 
     /// Marks the current tree state leaf as a value that we're interested in
@@ -201,15 +215,15 @@ impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
     /// Obtains an authentication path to the value specified in the tree.
     /// Returns `None` if there is no available authentication path to the
     /// specified value.
-    fn authentication_path(&self, value: &H) -> Option<(Position, Vec<H>)> {
-        self.tree_state.authentication_path(value)
+    fn authentication_path(&self, position: Position, value: &H) -> Option<Vec<H>> {
+        self.tree_state.authentication_path(position, value)
     }
 
     /// Marks the specified tree state value as a value we're no longer
     /// interested in maintaining a witness for. Returns true if successful and
     /// false if the value is not a known witness.
-    fn remove_witness(&mut self, value: &H) -> bool {
-        self.tree_state.remove_witness(value)
+    fn remove_witness(&mut self, position: Position, value: &H) -> bool {
+        self.tree_state.remove_witness(position, value)
     }
 
     /// Marks the current tree state as a checkpoint if it is not already a
@@ -218,8 +232,8 @@ impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
         let is_witnessed = self
             .tree_state
             .current_leaf()
-            .iter()
-            .any(|l| self.tree_state.is_witnessed(l));
+            .into_iter()
+            .any(|(p, l)| self.tree_state.is_witnessed(p, &l));
         self.checkpoints
             .push((self.tree_state.clone(), is_witnessed));
         if self.checkpoints.len() > self.max_checkpoints {
@@ -234,9 +248,10 @@ impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
         if let Some((checkpointed_state, is_witnessed)) = self.checkpoints.pop() {
             // if there are any witnessed leaves in the current tree state
             // that would be removed, we don't rewind
-            if self.tree_state.witnesses.iter().any(|&(idx, _)| {
-                idx + 1 > checkpointed_state.current_offset
-                    || (idx + 1 == checkpointed_state.current_offset && !is_witnessed)
+            if self.tree_state.witnesses.iter().any(|&(pos, _)| {
+                let offset: usize = (pos + 1).try_into().unwrap();
+                offset > checkpointed_state.current_offset
+                    || (offset == checkpointed_state.current_offset && !is_witnessed)
             }) {
                 self.checkpoints.push((checkpointed_state, is_witnessed));
                 false


### PR DESCRIPTION
Previously, we didn't correctly handle cases where the incremental merkle tree had duplicate leaf values; we just ignored every duplicate leaf added to the tree when constructing an authentication path. This PR allows for duplicate leaf values to be uniquely identified and correct authorization paths to be generated for all such leaves.

This builds atop #15 