### PR TITLE
Fix incorrect consistency check for auth_fragment construction.

### DIFF
--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -374,7 +374,6 @@ impl<A> AuthFragment<A> {
     /// perform any meaningful validation that the provided values
     /// are valid.
     pub fn from_parts(position: Position, altitudes_observed: usize, values: Vec<A>) -> Self {
-        assert!(altitudes_observed <= values.len());
         Self {
             position,
             altitudes_observed,


### PR DESCRIPTION
This was just entirely wrong; it will often be the case that we've
observed several altitudes but have an empty list of values within
a particular fragment.