### PR TITLE
incrementalmerkletree 0.3.0-beta.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementalmerkletree"
-version = "0.2.0"
+version = "0.3.0-beta.1"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Kris Nuttycombe <kris@nutty.land>",


### PR DESCRIPTION
Closes zcash/incrementalmerkletree#25.