### PR TITLE
Always query the tree by position, not hash.

### DIFF
--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -524,7 +524,7 @@ impl<H: Ord> MerkleBridge<H> {
 }
 
 impl<'a, H: Hashable + Ord + Clone + 'a> MerkleBridge<H> {
-    /// Returns the current leaf and its position.
+    /// Returns the current leaf.
     pub fn current_leaf(&self) -> &H {
         self.frontier.current_leaf()
     }
@@ -919,8 +919,8 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
         self.current_bridge.as_ref().map(|b| b.current_leaf())
     }
 
-    /// Returns `true` if the tree can produce an authentication path for
-    /// the specified leaf value.
+    /// Returns the leaf at the specified position if the tree can produce
+    /// an authentication path for it.
     fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
         self.saved
             .get(&position)
@@ -928,8 +928,7 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
     }
 
     /// Marks the current tree state leaf as a value that we're interested in
-    /// witnessing. Returns the current position and leaf value if the tree
-    /// is non-empty.
+    /// witnessing. Returns the current position if the tree is non-empty.
     fn witness(&mut self) -> Option<Position> {
         match self.current_bridge.take() {
             Some(mut cur_b) => {
@@ -966,7 +965,7 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
 
     /// Obtains an authentication path to the value specified in the tree.
     /// Returns `None` if there is no available authentication path to the
-    /// specified value.
+    /// value at the specified position.
     fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
         self.saved.get(&position).and_then(|idx| {
             let frontier = &self.prior_bridges[*idx].frontier;
@@ -1033,11 +1032,11 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
         })
     }
 
-    /// Marks the specified tree state value as a value we're no longer
-    /// interested in maintaining a witness for. Use the `garbage_collect`
-    /// method to fully remove witness information.
+    /// Marks the specified posisition as a value we're no longer interested in maintaining a
+    /// witness for. Use the `garbage_collect` method to fully remove witness information.
     ///
-    /// Returns true if successful and false if the value is not a known witness.
+    /// Returns true if successful and false if we were already not maintaining a
+    /// witness at this position.
     fn remove_witness(&mut self, position: Position) -> bool {
         if let Some(idx) = self.saved.remove(&position) {
             // If the index of the saved value is one that could have been known

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -104,8 +104,8 @@ impl<H> NonEmptyFrontier<H> {
 }
 
 impl<H: Hashable + Clone> NonEmptyFrontier<H> {
-    pub fn current_leaf(&self) -> (Position, H) {
-        (self.position, self.leaf.value().clone())
+    pub fn current_leaf(&self) -> &H {
+        self.leaf.value()
     }
 
     /// Appends a new leaf value to the Merkle frontier. If the current leaf subtree
@@ -525,7 +525,7 @@ impl<H: Ord> MerkleBridge<H> {
 
 impl<'a, H: Hashable + Ord + Clone + 'a> MerkleBridge<H> {
     /// Returns the current leaf and its position.
-    pub fn current_leaf(&self) -> (Position, H) {
+    pub fn current_leaf(&self) -> &H {
         self.frontier.current_leaf()
     }
 
@@ -621,7 +621,7 @@ impl<'a, H: Hashable + Ord + Clone + 'a> MerkleBridge<H> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Checkpoint<H: Ord> {
+pub struct Checkpoint {
     /// The number of bridges that will be retained in a rewind.
     bridges_len: usize,
     /// A flag indicating whether or not the current state of the tree
@@ -632,14 +632,14 @@ pub struct Checkpoint<H: Ord> {
     /// witnesses to the BridgeTree's "saved" list. If the witness was newly created since the
     /// checkpoint, we don't need to remember when we forget it because both the witness
     /// creation and removal will be reverted in the rollback.
-    forgotten: BTreeMap<(Position, H), usize>,
+    forgotten: BTreeMap<Position, usize>,
 }
 
-impl<H: Ord> Checkpoint<H> {
+impl Checkpoint {
     pub fn from_parts(
         bridges_len: usize,
         is_witnessed: bool,
-        forgotten: BTreeMap<(Position, H), usize>,
+        forgotten: BTreeMap<Position, usize>,
     ) -> Self {
         Self {
             bridges_len,
@@ -664,7 +664,7 @@ impl<H: Ord> Checkpoint<H> {
         self.is_witnessed
     }
 
-    pub fn forgotten(&self) -> &BTreeMap<(Position, H), usize> {
+    pub fn forgotten(&self) -> &BTreeMap<Position, usize> {
         &self.forgotten
     }
 
@@ -683,11 +683,11 @@ pub struct BridgeTree<H: Ord, const DEPTH: u8> {
     prior_bridges: Vec<MerkleBridge<H>>,
     /// The current (mutable) bridge at the tip of the tree.
     current_bridge: Option<MerkleBridge<H>>,
-    /// A map from positions and hashes for which we wish to be able to compute an
+    /// A map from positions for which we wish to be able to compute an
     /// authentication path to index in the bridges vector.
-    saved: BTreeMap<(Position, H), usize>,
+    saved: BTreeMap<Position, usize>,
     /// A stack of bridge indices to which it's possible to rewind directly.
-    checkpoints: Vec<Checkpoint<H>>,
+    checkpoints: Vec<Checkpoint>,
     /// The maximum number of checkpoints to retain. If this number is
     /// exceeded, the oldest checkpoint will be dropped when creating
     /// a new checkpoint.
@@ -698,7 +698,7 @@ impl<H: Hashable + Ord + Debug, const DEPTH: u8> Debug for BridgeTree<H, DEPTH> 
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
-            "BridgeTree {{\n  depth: {:?},\n  prior_bridges: {:?},\n  current_bridge: {:?},\n,  saved: {:?},\n  checkpoints: {:?},\n  max_checkpoints: {:?}\n}}",
+            "BridgeTree {{\n  depth: {:?},\n  prior_bridges: {:?},\n  current_bridge: {:?},\n  saved: {:?},\n  checkpoints: {:?},\n  max_checkpoints: {:?}\n}}",
             DEPTH, self.prior_bridges, self.current_bridge, self.saved, self.checkpoints, self.max_checkpoints
         )
     }
@@ -737,12 +737,12 @@ impl<H: Ord, const DEPTH: u8> BridgeTree<H, DEPTH> {
         &self.current_bridge
     }
 
-    pub fn witnessed_indices(&self) -> &BTreeMap<(Position, H), usize> {
+    pub fn witnessed_indices(&self) -> &BTreeMap<Position, usize> {
         &self.saved
     }
 
     /// Returns the checkpoints to which this tree may be rewound.
-    pub fn checkpoints(&self) -> &[Checkpoint<H>] {
+    pub fn checkpoints(&self) -> &[Checkpoint] {
         &self.checkpoints
     }
 
@@ -772,14 +772,14 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> BridgeTree<H, DEPTH> {
     pub fn from_parts(
         prior_bridges: Vec<MerkleBridge<H>>,
         current_bridge: Option<MerkleBridge<H>>,
-        saved: BTreeMap<(Position, H), usize>,
-        checkpoints: Vec<Checkpoint<H>>,
+        saved: BTreeMap<Position, usize>,
+        checkpoints: Vec<Checkpoint>,
         max_checkpoints: usize,
     ) -> Result<Self, BridgeTreeError> {
         // check that saved values correspond to bridges
         if saved
             .iter()
-            .any(|(key, i)| i >= &prior_bridges.len() || &prior_bridges[*i].current_leaf() != key)
+            .any(|(pos, i)| i >= &prior_bridges.len() || &prior_bridges[*i].position() != pos)
         {
             return Err(BridgeTreeError::InvalidWitnessIndex);
         }
@@ -826,7 +826,7 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> BridgeTree<H, DEPTH> {
             // Get a list of the leaf positions that we need to retain. This consists of
             // all the saved leaves, plus all the leaves that have been forgotten since
             // the most distant checkpoint to which we could rewind.
-            let remember: BTreeSet<(Position, H)> = self
+            let remember: BTreeSet<Position> = self
                 .saved
                 .keys()
                 .chain(self.checkpoints.iter().flat_map(|c| c.forgotten.keys()))
@@ -841,11 +841,11 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> BridgeTree<H, DEPTH> {
                 .enumerate()
             {
                 if let Some(cur_bridge) = cur {
-                    let witness_key = cur_bridge.current_leaf();
-                    let mut new_cur = if remember.contains(&witness_key) || i > gc_len {
+                    let pos = cur_bridge.position();
+                    let mut new_cur = if remember.contains(&pos) || i > gc_len {
                         // We need to remember cur_bridge; update its save index & put next_bridge
                         // on the chopping block
-                        if let Some(idx) = self.saved.get_mut(&witness_key) {
+                        if let Some(idx) = self.saved.get_mut(&pos) {
                             *idx -= merged;
                         }
 
@@ -915,23 +915,25 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
     }
 
     /// Returns the most recently appended leaf value.
-    fn current_leaf(&self) -> Option<(Position, H)> {
+    fn current_leaf(&self) -> Option<&H> {
         self.current_bridge.as_ref().map(|b| b.current_leaf())
     }
 
     /// Returns `true` if the tree can produce an authentication path for
     /// the specified leaf value.
-    fn is_witnessed(&self, position: Position, value: &H) -> bool {
-        self.saved.contains_key(&(position, value.clone()))
+    fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
+        self.saved
+            .get(&position)
+            .and_then(|idx| self.prior_bridges.get(*idx).map(|b| b.current_leaf()))
     }
 
     /// Marks the current tree state leaf as a value that we're interested in
     /// witnessing. Returns the current position and leaf value if the tree
     /// is non-empty.
-    fn witness(&mut self) -> Option<(Position, H)> {
+    fn witness(&mut self) -> Option<Position> {
         match self.current_bridge.take() {
             Some(mut cur_b) => {
-                let key = cur_b.current_leaf();
+                let pos = cur_b.position();
                 // If the latest bridge is a newly created checkpoint, the last prior
                 // bridge will have the same position and all we need to do is mark
                 // the checkpointed leaf as being saved.
@@ -944,8 +946,8 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
                     // sure that we have an auth fragment tracking the witnessed leaf
                     cur_b
                         .auth_fragments
-                        .entry(key.0)
-                        .or_insert_with(|| AuthFragment::new(key.0));
+                        .entry(pos)
+                        .or_insert_with(|| AuthFragment::new(pos));
                     self.current_bridge = Some(cur_b);
                 } else {
                     let successor = cur_b.successor(true);
@@ -954,9 +956,9 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
                 }
 
                 self.saved
-                    .entry(key.clone())
+                    .entry(pos)
                     .or_insert(self.prior_bridges.len() - 1);
-                Some(key)
+                Some(pos)
             }
             None => None,
         }
@@ -965,8 +967,8 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
     /// Obtains an authentication path to the value specified in the tree.
     /// Returns `None` if there is no available authentication path to the
     /// specified value.
-    fn authentication_path(&self, position: Position, value: &H) -> Option<Vec<H>> {
-        self.saved.get(&(position, value.clone())).and_then(|idx| {
+    fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
+        self.saved.get(&position).and_then(|idx| {
             let frontier = &self.prior_bridges[*idx].frontier;
 
             // Fuse the following bridges to obtain a bridge that has all
@@ -1036,16 +1038,15 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
     /// method to fully remove witness information.
     ///
     /// Returns true if successful and false if the value is not a known witness.
-    fn remove_witness(&mut self, position: Position, value: &H) -> bool {
-        let key = (position, value.clone());
-        if let Some(idx) = self.saved.remove(&key) {
+    fn remove_witness(&mut self, position: Position) -> bool {
+        if let Some(idx) = self.saved.remove(&position) {
             // If the index of the saved value is one that could have been known
             // at the last checkpoint, then add it to the set of those forgotten
             // during the current checkpoint span so that it can be restored
             // on rollback.
             if let Some(c) = self.checkpoints.last_mut() {
                 if c.bridges_len > 0 && idx < c.bridges_len - 1 {
-                    c.forgotten.insert(key, idx);
+                    c.forgotten.insert(position, idx);
                 }
             }
             true
@@ -1059,6 +1060,8 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
     fn checkpoint(&mut self) {
         match self.current_bridge.take() {
             Some(cur_b) => {
+                let is_witnessed = self.get_witnessed_leaf(cur_b.position()).is_some();
+
                 // Do not create a duplicate bridge
                 if self
                     .prior_bridges
@@ -1071,13 +1074,10 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
                     self.prior_bridges.push(cur_b);
                 }
 
-                let len = self.prior_bridges.len();
-                let is_witnessed = self
-                    .current_leaf()
-                    .map_or(false, |(pos, l)| self.is_witnessed(pos, &l));
-
-                self.checkpoints
-                    .push(Checkpoint::at_length(len, is_witnessed));
+                self.checkpoints.push(Checkpoint::at_length(
+                    self.prior_bridges.len(),
+                    is_witnessed,
+                ));
             }
             None => {
                 self.checkpoints.push(Checkpoint::at_length(0, false));
@@ -1113,10 +1113,9 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
-    use proptest::sample::SizeRange;
 
     use super::*;
-    use crate::tests::{apply_operation, arb_operations};
+    use crate::tests::{apply_operation, arb_operation};
     use crate::{Frontier, Tree};
 
     #[test]
@@ -1130,24 +1129,26 @@ mod tests {
 
     fn arb_bridgetree<G: Strategy + Clone>(
         item_gen: G,
-        count: impl Into<SizeRange>,
+        max_count: usize,
     ) -> impl Strategy<Value = BridgeTree<G::Value, 8>>
     where
         G::Value: Hashable + Ord + Clone + Debug + 'static,
     {
-        arb_operations(item_gen, count).prop_map(|ops| {
-            let mut tree: BridgeTree<G::Value, 8> = BridgeTree::new(10);
-            for op in ops {
-                apply_operation(&mut tree, op);
-            }
-            tree
-        })
+        proptest::collection::vec(arb_operation(item_gen, 0..max_count), 0..max_count).prop_map(
+            |ops| {
+                let mut tree: BridgeTree<G::Value, 8> = BridgeTree::new(10);
+                for op in ops {
+                    apply_operation(&mut tree, op);
+                }
+                tree
+            },
+        )
     }
 
     proptest! {
         #[test]
         fn bridgetree_from_parts(
-            tree in arb_bridgetree((97u8..123).prop_map(|c| char::from(c).to_string()), 1..100)
+            tree in arb_bridgetree((97u8..123).prop_map(|c| char::from(c).to_string()), 100)
         ) {
             assert_eq!(
                 BridgeTree::from_parts(
@@ -1163,7 +1164,7 @@ mod tests {
 
         #[test]
         fn prop_garbage_collect(
-            tree in arb_bridgetree((97u8..123).prop_map(|c| char::from(c).to_string()), 1..100)
+            tree in arb_bridgetree((97u8..123).prop_map(|c| char::from(c).to_string()), 100)
         ) {
             let mut tree_mut = tree.clone();
             // ensure we have enough checkpoints to not rewind past the state `tree` is in
@@ -1175,10 +1176,10 @@ mod tests {
 
             tree_mut.rewind();
 
-            for (pos, h) in tree.saved.keys() {
+            for pos in tree.saved.keys() {
                 assert_eq!(
-                    tree.authentication_path(*pos, h),
-                    tree_mut.authentication_path(*pos, h)
+                    tree.authentication_path(*pos),
+                    tree_mut.authentication_path(*pos)
                 );
             }
         }
@@ -1262,22 +1263,22 @@ mod tests {
             if i % 7 == 0 {
                 t.witness();
                 if i > 0 && i % 2 == 0 {
-                    to_unwitness.push((Position::from(i), elem));
+                    to_unwitness.push(Position::from(i));
                 } else {
-                    has_auth_path.push((Position::from(i), elem));
+                    has_auth_path.push(Position::from(i));
                 }
             }
             if i % 11 == 0 && !to_unwitness.is_empty() {
-                let (pos, elem) = to_unwitness.remove(0);
-                t.remove_witness(pos, &elem);
+                let pos = to_unwitness.remove(0);
+                t.remove_witness(pos);
             }
         }
         // 32 = 20 (checkpointed) + 14 (witnessed) - 2 (witnessed & checkpointed)
         assert_eq!(t.prior_bridges().len(), 20 + 14 - 2);
         let auth_paths = has_auth_path
             .iter()
-            .map(|(pos, elem)| {
-                t.authentication_path(*pos, elem)
+            .map(|pos| {
+                t.authentication_path(*pos)
                     .expect("Must be able to get auth path")
             })
             .collect::<Vec<_>>();
@@ -1286,8 +1287,8 @@ mod tests {
         assert_eq!(t.prior_bridges().len(), 32 - 10 + 1 - 3);
         let retained_auth_paths = has_auth_path
             .iter()
-            .map(|(pos, elem)| {
-                t.authentication_path(*pos, elem)
+            .map(|pos| {
+                t.authentication_path(*pos)
                     .expect("Must be able to get auth path")
             })
             .collect::<Vec<_>>();

--- a/src/bridgetree.rs
+++ b/src/bridgetree.rs
@@ -108,7 +108,6 @@ impl<H: Hashable + Clone> NonEmptyFrontier<H> {
         self.leaf.value()
     }
 
-    /// Appends a new leaf value to the Merkle frontier. If the current leaf subtree
     /// of two nodes is full (if the current leaf before the append is a `Leaf::Right`)
     /// then recompute the ommers by hashing together full subtrees until an empty
     /// ommer slot is found.
@@ -309,9 +308,6 @@ impl<H, const DEPTH: u8> Frontier<H, DEPTH> {
 }
 
 impl<H: Hashable + Clone, const DEPTH: u8> crate::Frontier<H> for Frontier<H, DEPTH> {
-    /// Appends a new value to the tree at the next available slot. Returns true
-    /// if successful and false if the frontier would exceed the maximum
-    /// allowed depth.
     fn append(&mut self, value: &H) -> bool {
         if let Some(frontier) = self.frontier.as_mut() {
             if frontier.position().is_complete(Altitude(DEPTH)) {
@@ -326,7 +322,6 @@ impl<H: Hashable + Clone, const DEPTH: u8> crate::Frontier<H> for Frontier<H, DE
         }
     }
 
-    /// Obtains the current root of this Merkle frontier.
     fn root(&self) -> H {
         self.frontier
             .as_ref()
@@ -893,7 +888,6 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> crate::Frontier<H> for BridgeTr
         }
     }
 
-    /// Obtains the current root of this Merkle tree.
     fn root(&self) -> H {
         self.current_bridge
             .as_ref()
@@ -914,21 +908,16 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
         self.current_bridge.as_ref().map(|b| b.position())
     }
 
-    /// Returns the most recently appended leaf value.
     fn current_leaf(&self) -> Option<&H> {
         self.current_bridge.as_ref().map(|b| b.current_leaf())
     }
 
-    /// Returns the leaf at the specified position if the tree can produce
-    /// an authentication path for it.
     fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
         self.saved
             .get(&position)
             .and_then(|idx| self.prior_bridges.get(*idx).map(|b| b.current_leaf()))
     }
 
-    /// Marks the current tree state leaf as a value that we're interested in
-    /// witnessing. Returns the current position if the tree is non-empty.
     fn witness(&mut self) -> Option<Position> {
         match self.current_bridge.take() {
             Some(mut cur_b) => {
@@ -963,9 +952,6 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
         }
     }
 
-    /// Obtains an authentication path to the value specified in the tree.
-    /// Returns `None` if there is no available authentication path to the
-    /// value at the specified position.
     fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
         self.saved.get(&position).and_then(|idx| {
             let frontier = &self.prior_bridges[*idx].frontier;
@@ -1032,11 +1018,6 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
         })
     }
 
-    /// Marks the specified posisition as a value we're no longer interested in maintaining a
-    /// witness for. Use the `garbage_collect` method to fully remove witness information.
-    ///
-    /// Returns true if successful and false if we were already not maintaining a
-    /// witness at this position.
     fn remove_witness(&mut self, position: Position) -> bool {
         if let Some(idx) = self.saved.remove(&position) {
             // If the index of the saved value is one that could have been known
@@ -1054,8 +1035,6 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
         }
     }
 
-    /// Marks the current tree state as a checkpoint if it is not already a
-    /// checkpoint.
     fn checkpoint(&mut self) {
         match self.current_bridge.take() {
             Some(cur_b) => {
@@ -1088,8 +1067,6 @@ impl<H: Hashable + Ord + Clone, const DEPTH: u8> Tree<H> for BridgeTree<H, DEPTH
         }
     }
 
-    /// Rewinds the tree state to the previous checkpoint. This function will
-    /// return false and leave the tree unmodified if no checkpoints exist.
     fn rewind(&mut self) -> bool {
         match self.checkpoints.pop() {
             Some(mut c) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -761,7 +761,6 @@ pub(crate) mod tests {
     }
 
     impl<H: Hashable + Ord + Clone + Debug, const DEPTH: u8> Tree<H> for CombinedTree<H, DEPTH> {
-        /// Returns the most recently appended leaf value.
         fn current_position(&self) -> Option<Position> {
             let a = self.inefficient.current_position();
             let b = self.efficient.current_position();
@@ -769,7 +768,6 @@ pub(crate) mod tests {
             a
         }
 
-        /// Returns the most recently appended leaf value.
         fn current_leaf(&self) -> Option<&H> {
             let a = self.inefficient.current_leaf();
             let b = self.efficient.current_leaf();
@@ -777,8 +775,6 @@ pub(crate) mod tests {
             a
         }
 
-        /// Returns the leaf at the specified position if the tree can produce
-        /// an authentication path for it.
         fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
             let a = self.inefficient.get_witnessed_leaf(position);
             let b = self.efficient.get_witnessed_leaf(position);
@@ -786,8 +782,6 @@ pub(crate) mod tests {
             a
         }
 
-        /// Marks the current tree state leaf as a value that we're interested in
-        /// witnessing. Returns the current position if the tree is non-empty.
         fn witness(&mut self) -> Option<Position> {
             let a = self.inefficient.witness();
             let b = self.efficient.witness();
@@ -795,9 +789,6 @@ pub(crate) mod tests {
             a
         }
 
-        /// Obtains an authentication path to the value specified in the tree.
-        /// Returns `None` if there is no available authentication path to the
-        /// specified value.
         fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
             let a = self.inefficient.authentication_path(position);
             let b = self.efficient.authentication_path(position);
@@ -805,9 +796,6 @@ pub(crate) mod tests {
             a
         }
 
-        /// Marks the value at the specified position as a value we're no longer
-        /// interested in maintaining a witness for. Returns true if successful and
-        /// false if we were already not maintaining a witness at this position.
         fn remove_witness(&mut self, position: Position) -> bool {
             let a = self.inefficient.remove_witness(position);
             let b = self.efficient.remove_witness(position);
@@ -815,16 +803,11 @@ pub(crate) mod tests {
             a
         }
 
-        /// Marks the current tree state as a checkpoint if it is not already a
-        /// checkpoint.
         fn checkpoint(&mut self) {
             self.inefficient.checkpoint();
             self.efficient.checkpoint();
         }
 
-        /// Rewinds the tree state to the previous checkpoint. This function will
-        /// fail and return false if there is no previous checkpoint or in the event
-        /// witness data would be destroyed in the process.
         fn rewind(&mut self) -> bool {
             let a = self.inefficient.rewind();
             let b = self.efficient.rewind();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use std::ops::{Add, AddAssign, Sub};
 /// A type-safe wrapper for indexing into "levels" of a binary tree, such that
 /// nodes at altitude `0` are leaves, nodes at altitude `1` are parents
 /// of nodes at altitude `0`, and so forth. This type is capable of
-/// representing altitudes in trees containing up to 2^256 leaves.
+/// representing altitudes in trees containing up to 2^255 leaves.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct Altitude(u8);
@@ -238,24 +238,24 @@ pub trait Tree<H>: Frontier<H> {
     /// Returns the most recently appended leaf value.
     fn current_leaf(&self) -> Option<&H>;
 
-    /// Returns the leaf for which tree can produce an authentication path
-    /// at the specified position in the tree.
+    /// Returns the leaf at the specified position if the tree can produce
+    /// an authentication path for it.
     fn get_witnessed_leaf(&self, position: Position) -> Option<&H>;
 
     /// Marks the current leaf as one for which we're interested in producing
     /// an authentication path. Returns an optional value containing the
-    /// current position and leaf value if successful or if the current
-    /// value was already marked, or None if the tree is empty.
+    /// current position if successful or if the current value was already
+    /// marked, or None if the tree is empty.
     fn witness(&mut self) -> Option<Position>;
 
-    /// Obtains an authentication path to the value specified in the tree.
-    /// Returns `None` if there is no available authentication path to the
-    /// specified value.
+    /// Obtains an authentication path to the value at the specified position.
+    /// Returns `None` if there is no available authentication path to that
+    /// value.
     fn authentication_path(&self, position: Position) -> Option<Vec<H>>;
 
-    /// Marks the specified tree state value as a value we're no longer
+    /// Marks the value at the specified position as a value we're no longer
     /// interested in maintaining a witness for. Returns true if successful and
-    /// false if the value is not a known witness.
+    /// false if we were already not maintaining a witness at this position.
     fn remove_witness(&mut self, position: Position) -> bool;
 
     /// Creates a new checkpoint for the current tree state. It is valid to
@@ -769,7 +769,7 @@ pub(crate) mod tests {
             a
         }
 
-        /// Returns the most recently appended leaf value and its position in the tree.
+        /// Returns the most recently appended leaf value.
         fn current_leaf(&self) -> Option<&H> {
             let a = self.inefficient.current_leaf();
             let b = self.efficient.current_leaf();
@@ -777,8 +777,8 @@ pub(crate) mod tests {
             a
         }
 
-        /// Returns `true` if the tree can produce an authentication path for
-        /// the specified leaf value from the specified position in the tree.
+        /// Returns the leaf at the specified position if the tree can produce
+        /// an authentication path for it.
         fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
             let a = self.inefficient.get_witnessed_leaf(position);
             let b = self.efficient.get_witnessed_leaf(position);
@@ -787,8 +787,7 @@ pub(crate) mod tests {
         }
 
         /// Marks the current tree state leaf as a value that we're interested in
-        /// witnessing. Returns the current position and leaf value if the tree
-        /// is non-empty.
+        /// witnessing. Returns the current position if the tree is non-empty.
         fn witness(&mut self) -> Option<Position> {
             let a = self.inefficient.witness();
             let b = self.efficient.witness();
@@ -806,9 +805,9 @@ pub(crate) mod tests {
             a
         }
 
-        /// Marks the specified tree state value as a value we're no longer
+        /// Marks the value at the specified position as a value we're no longer
         /// interested in maintaining a witness for. Returns true if successful and
-        /// false if the value is not a known witness.
+        /// false if we were already not maintaining a witness at this position.
         fn remove_witness(&mut self, position: Position) -> bool {
             let a = self.inefficient.remove_witness(position);
             let b = self.efficient.remove_witness(position);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,27 +236,27 @@ pub trait Tree<H>: Frontier<H> {
     fn current_position(&self) -> Option<Position>;
 
     /// Returns the most recently appended leaf value.
-    fn current_leaf(&self) -> Option<(Position, H)>;
+    fn current_leaf(&self) -> Option<&H>;
 
-    /// Returns `true` if the tree can produce an authentication path for
-    /// the specified leaf value from the specified position in the tree.
-    fn is_witnessed(&self, position: Position, value: &H) -> bool;
+    /// Returns the leaf for which tree can produce an authentication path
+    /// at the specified position in the tree.
+    fn get_witnessed_leaf(&self, position: Position) -> Option<&H>;
 
     /// Marks the current leaf as one for which we're interested in producing
     /// an authentication path. Returns an optional value containing the
     /// current position and leaf value if successful or if the current
     /// value was already marked, or None if the tree is empty.
-    fn witness(&mut self) -> Option<(Position, H)>;
+    fn witness(&mut self) -> Option<Position>;
 
     /// Obtains an authentication path to the value specified in the tree.
     /// Returns `None` if there is no available authentication path to the
     /// specified value.
-    fn authentication_path(&self, position: Position, value: &H) -> Option<Vec<H>>;
+    fn authentication_path(&self, position: Position) -> Option<Vec<H>>;
 
     /// Marks the specified tree state value as a value we're no longer
     /// interested in maintaining a witness for. Returns true if successful and
     /// false if the value is not a known witness.
-    fn remove_witness(&mut self, position: Position, value: &H) -> bool;
+    fn remove_witness(&mut self, position: Position) -> bool;
 
     /// Creates a new checkpoint for the current tree state. It is valid to
     /// have multiple checkpoints for the same tree state, and each `rewind`
@@ -358,7 +358,7 @@ pub(crate) mod tests {
         tree.append(&"a".to_string());
         tree.witness();
         assert_eq!(
-            tree.authentication_path(Position::from(0), &"a".to_string()),
+            tree.authentication_path(Position::from(0)),
             Some(vec![
                 "_".to_string(),
                 "__".to_string(),
@@ -369,7 +369,7 @@ pub(crate) mod tests {
 
         tree.append(&"b".to_string());
         assert_eq!(
-            tree.authentication_path(Position::zero(), &"a".to_string()),
+            tree.authentication_path(Position::zero()),
             Some(vec![
                 "b".to_string(),
                 "__".to_string(),
@@ -381,7 +381,7 @@ pub(crate) mod tests {
         tree.append(&"c".to_string());
         tree.witness();
         assert_eq!(
-            tree.authentication_path(Position::from(2), &"c".to_string()),
+            tree.authentication_path(Position::from(2)),
             Some(vec![
                 "_".to_string(),
                 "ab".to_string(),
@@ -392,7 +392,7 @@ pub(crate) mod tests {
 
         tree.append(&"d".to_string());
         assert_eq!(
-            tree.authentication_path(Position::from(2), &"c".to_string()),
+            tree.authentication_path(Position::from(2)),
             Some(vec![
                 "d".to_string(),
                 "ab".to_string(),
@@ -403,7 +403,7 @@ pub(crate) mod tests {
 
         tree.append(&"e".to_string());
         assert_eq!(
-            tree.authentication_path(Position::from(2), &"c".to_string()),
+            tree.authentication_path(Position::from(2)),
             Some(vec![
                 "d".to_string(),
                 "ab".to_string(),
@@ -422,7 +422,7 @@ pub(crate) mod tests {
         tree.append(&"h".to_string());
 
         assert_eq!(
-            tree.authentication_path(Position::zero(), &"a".to_string()),
+            tree.authentication_path(Position::zero()),
             Some(vec![
                 "b".to_string(),
                 "cd".to_string(),
@@ -445,7 +445,7 @@ pub(crate) mod tests {
         tree.append(&"g".to_string());
 
         assert_eq!(
-            tree.authentication_path(Position::from(5), &"f".to_string()),
+            tree.authentication_path(Position::from(5)),
             Some(vec![
                 "e".to_string(),
                 "g_".to_string(),
@@ -462,7 +462,7 @@ pub(crate) mod tests {
         tree.append(&'l'.to_string());
 
         assert_eq!(
-            tree.authentication_path(Position::from(10), &"k".to_string()),
+            tree.authentication_path(Position::from(10)),
             Some(vec![
                 "l".to_string(),
                 "ij".to_string(),
@@ -485,7 +485,7 @@ pub(crate) mod tests {
         }
 
         assert_eq!(
-            tree.authentication_path(Position::zero(), &"a".to_string()),
+            tree.authentication_path(Position::zero()),
             Some(vec![
                 "b".to_string(),
                 "cd".to_string(),
@@ -509,7 +509,7 @@ pub(crate) mod tests {
         assert!(tree.rewind());
 
         assert_eq!(
-            tree.authentication_path(Position::from(2), &"c".to_string()),
+            tree.authentication_path(Position::from(2)),
             Some(vec![
                 "d".to_string(),
                 "ab".to_string(),
@@ -522,10 +522,7 @@ pub(crate) mod tests {
         tree.append(&'a'.to_string());
         tree.append(&'b'.to_string());
         tree.witness();
-        assert_eq!(
-            tree.authentication_path(Position::from(0), &"b".to_string()),
-            None
-        );
+        assert_eq!(tree.authentication_path(Position::from(0)), None);
 
         let mut tree = new_tree(100);
         for c in 'a'..'n' {
@@ -538,7 +535,7 @@ pub(crate) mod tests {
         tree.append(&'p'.to_string());
 
         assert_eq!(
-            tree.authentication_path(Position::from(12), &"m".to_string()),
+            tree.authentication_path(Position::from(12)),
             Some(vec![
                 "n".to_string(),
                 "op".to_string(),
@@ -553,7 +550,7 @@ pub(crate) mod tests {
             .chain(Some(Witness))
             .chain(Some(Append('m'.to_string())))
             .chain(Some(Append('n'.to_string())))
-            .chain(Some(Authpath(11usize.into(), 'l'.to_string())))
+            .chain(Some(Authpath(11usize.into())))
             .collect::<Vec<_>>();
 
         let mut tree = new_tree(100);
@@ -585,7 +582,7 @@ pub(crate) mod tests {
         t.append(&"b".to_string());
         t.witness();
         assert!(t.rewind());
-        assert_eq!(Some((Position::from(0), "a".to_string())), t.current_leaf());
+        assert_eq!(Some(Position::from(0)), t.current_position());
 
         let mut t = new_tree(100);
         t.append(&"a".to_string());
@@ -599,7 +596,7 @@ pub(crate) mod tests {
         t.witness();
         t.append(&"a".to_string());
         assert!(t.rewind());
-        assert_eq!(Some((Position::from(0), "a".to_string())), t.current_leaf());
+        assert_eq!(Some(Position::from(0)), t.current_position());
 
         let mut t = new_tree(100);
         t.append(&"a".to_string());
@@ -618,34 +615,34 @@ pub(crate) mod tests {
         tree.witness();
         tree.checkpoint();
         assert!(tree.rewind());
-        assert!(tree.remove_witness(0usize.into(), &"e".to_string()));
+        assert!(tree.remove_witness(0usize.into()));
 
         let mut tree = new_tree(100);
         tree.append(&"e".to_string());
         tree.checkpoint();
         tree.witness();
         assert!(tree.rewind());
-        assert!(!tree.remove_witness(0usize.into(), &"e".to_string()));
+        assert!(!tree.remove_witness(0usize.into()));
 
         let mut tree = new_tree(100);
         tree.append(&"e".to_string());
         tree.witness();
         tree.checkpoint();
-        assert!(tree.remove_witness(0usize.into(), &"e".to_string()));
+        assert!(tree.remove_witness(0usize.into()));
         assert!(tree.rewind());
-        assert!(tree.remove_witness(0usize.into(), &"e".to_string()));
+        assert!(tree.remove_witness(0usize.into()));
 
         let mut tree = new_tree(100);
         tree.append(&"e".to_string());
         tree.witness();
-        assert!(tree.remove_witness(0usize.into(), &"e".to_string()));
+        assert!(tree.remove_witness(0usize.into()));
         tree.checkpoint();
         assert!(tree.rewind());
-        assert!(!tree.remove_witness(0usize.into(), &"e".to_string()));
+        assert!(!tree.remove_witness(0usize.into()));
 
         let mut tree = new_tree(100);
         tree.append(&"a".to_string());
-        assert!(!tree.remove_witness(0usize.into(), &"a".to_string()));
+        assert!(!tree.remove_witness(0usize.into()));
         tree.checkpoint();
         assert!(tree.witness().is_some());
         assert!(tree.rewind());
@@ -654,9 +651,9 @@ pub(crate) mod tests {
         tree.append(&"a".to_string());
         tree.checkpoint();
         assert!(tree.witness().is_some());
-        assert!(tree.remove_witness(0usize.into(), &"a".to_string()));
+        assert!(tree.remove_witness(0usize.into()));
         assert!(tree.rewind());
-        assert!(!tree.remove_witness(0usize.into(), &"a".to_string()));
+        assert!(!tree.remove_witness(0usize.into()));
 
         // The following check_operations tests cover errors where the
         // test framework itself previously did not correctly handle
@@ -666,11 +663,11 @@ pub(crate) mod tests {
             Append(x.to_string())
         }
 
-        fn unwitness(pos: usize, x: &str) -> Operation<String> {
-            Unwitness(Position::from(pos), x.to_string())
+        fn unwitness(pos: usize) -> Operation<String> {
+            Unwitness(Position::from(pos))
         }
 
-        let ops = vec![append("x"), Checkpoint, Witness, Rewind, unwitness(0, "x")];
+        let ops = vec![append("x"), Checkpoint, Witness, Rewind, unwitness(0)];
         let result = check_operations(ops);
         assert!(
             matches!(result, Ok(())),
@@ -682,9 +679,9 @@ pub(crate) mod tests {
             append("d"),
             Checkpoint,
             Witness,
-            unwitness(0, "d"),
+            unwitness(0),
             Rewind,
-            unwitness(0, "d"),
+            unwitness(0),
         ];
         let result = check_operations(ops);
         assert!(
@@ -698,7 +695,7 @@ pub(crate) mod tests {
             Checkpoint,
             Witness,
             Checkpoint,
-            unwitness(0, "o"),
+            unwitness(0),
             Rewind,
             Rewind,
         ];
@@ -714,10 +711,10 @@ pub(crate) mod tests {
             Witness,
             append("m"),
             Checkpoint,
-            unwitness(0, "s"),
+            unwitness(0),
             Rewind,
-            unwitness(0, "s"),
-            unwitness(0, "m"),
+            unwitness(0),
+            unwitness(0),
         ];
         let result = check_operations(ops);
         assert!(
@@ -773,7 +770,7 @@ pub(crate) mod tests {
         }
 
         /// Returns the most recently appended leaf value and its position in the tree.
-        fn current_leaf(&self) -> Option<(Position, H)> {
+        fn current_leaf(&self) -> Option<&H> {
             let a = self.inefficient.current_leaf();
             let b = self.efficient.current_leaf();
             assert_eq!(a, b);
@@ -782,9 +779,9 @@ pub(crate) mod tests {
 
         /// Returns `true` if the tree can produce an authentication path for
         /// the specified leaf value from the specified position in the tree.
-        fn is_witnessed(&self, position: Position, value: &H) -> bool {
-            let a = self.inefficient.is_witnessed(position, value);
-            let b = self.efficient.is_witnessed(position, value);
+        fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
+            let a = self.inefficient.get_witnessed_leaf(position);
+            let b = self.efficient.get_witnessed_leaf(position);
             assert_eq!(a, b);
             a
         }
@@ -792,7 +789,7 @@ pub(crate) mod tests {
         /// Marks the current tree state leaf as a value that we're interested in
         /// witnessing. Returns the current position and leaf value if the tree
         /// is non-empty.
-        fn witness(&mut self) -> Option<(Position, H)> {
+        fn witness(&mut self) -> Option<Position> {
             let a = self.inefficient.witness();
             let b = self.efficient.witness();
             assert_eq!(a, b);
@@ -802,9 +799,9 @@ pub(crate) mod tests {
         /// Obtains an authentication path to the value specified in the tree.
         /// Returns `None` if there is no available authentication path to the
         /// specified value.
-        fn authentication_path(&self, position: Position, value: &H) -> Option<Vec<H>> {
-            let a = self.inefficient.authentication_path(position, value);
-            let b = self.efficient.authentication_path(position, value);
+        fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
+            let a = self.inefficient.authentication_path(position);
+            let b = self.efficient.authentication_path(position);
             assert_eq!(a, b);
             a
         }
@@ -812,9 +809,9 @@ pub(crate) mod tests {
         /// Marks the specified tree state value as a value we're no longer
         /// interested in maintaining a witness for. Returns true if successful and
         /// false if the value is not a known witness.
-        fn remove_witness(&mut self, position: Position, value: &H) -> bool {
-            let a = self.inefficient.remove_witness(position, value);
-            let b = self.efficient.remove_witness(position, value);
+        fn remove_witness(&mut self, position: Position) -> bool {
+            let a = self.inefficient.remove_witness(position);
+            let b = self.efficient.remove_witness(position);
             assert_eq!(a, b);
             a
         }
@@ -840,11 +837,14 @@ pub(crate) mod tests {
     #[derive(Clone, Debug)]
     pub enum Operation<A> {
         Append(A),
+        CurrentPosition,
+        CurrentLeaf,
         Witness,
-        Unwitness(Position, A),
+        WitnessedLeaf(Position),
+        Unwitness(Position),
         Checkpoint,
         Rewind,
-        Authpath(Position, A),
+        Authpath(Position),
     }
 
     use Operation::*;
@@ -856,12 +856,15 @@ pub(crate) mod tests {
                     assert!(tree.append(a), "append failed");
                     None
                 }
+                CurrentPosition => None,
+                CurrentLeaf => None,
                 Witness => {
                     assert!(tree.witness().is_some(), "witness failed");
                     None
                 }
-                Unwitness(p, a) => {
-                    assert!(tree.remove_witness(*p, a), "remove witness failed");
+                WitnessedLeaf(_) => None,
+                Unwitness(p) => {
+                    assert!(tree.remove_witness(*p), "remove witness failed");
                     None
                 }
                 Checkpoint => {
@@ -872,7 +875,7 @@ pub(crate) mod tests {
                     assert!(tree.rewind(), "rewind failed");
                     None
                 }
-                Authpath(p, a) => tree.authentication_path(*p, a).map(|xs| (*p, xs)),
+                Authpath(p) => tree.authentication_path(*p).map(|xs| (*p, xs)),
             }
         }
 
@@ -962,87 +965,29 @@ pub(crate) mod tests {
     }
 
     use proptest::prelude::*;
-    use proptest::sample::{select, SizeRange};
 
-    #[derive(Clone, Debug, PartialEq, Eq)]
-    enum OpType {
-        Append,
-        Witness,
-        Unwitness,
-        Checkpoint,
-        Rewind,
-        Authpath,
-    }
-
-    fn arb_operations_0<H: Clone + Debug + 'static>(
-        optypes: Vec<OpType>,
-        items: Vec<H>,
-    ) -> impl Strategy<Value = Vec<Operation<H>>> {
-        let mut idx = 0;
-        optypes
-            .iter()
-            .map(move |t| {
-                let items = items.clone();
-                match t {
-                    OpType::Append => {
-                        let item = items.get(idx).unwrap().clone();
-                        idx += 1;
-                        Just(Append(item)).boxed()
-                    }
-                    OpType::Witness => Just(Witness).boxed(),
-                    OpType::Unwitness => (0..(idx + 1))
-                        .prop_map(move |i| {
-                            let item = items.get(i).unwrap().clone();
-                            Unwitness(Position::from(i), item)
-                        })
-                        .boxed(),
-                    OpType::Checkpoint => Just(Checkpoint).boxed(),
-                    OpType::Rewind => Just(Rewind).boxed(),
-                    OpType::Authpath => (0..(idx + 1))
-                        .prop_map(move |i| {
-                            let item = items.get(i).unwrap().clone();
-                            Authpath(Position::from(i), item)
-                        })
-                        .boxed(),
-                }
-            })
-            .collect::<Vec<_>>()
-    }
-
-    fn arb_operations_1<G: Strategy>(
+    pub fn arb_operation<G: Strategy + Clone>(
         item_gen: G,
-        optypes: Vec<OpType>,
-    ) -> impl Strategy<Value = Vec<Operation<G::Value>>>
+        pos_gen: impl Strategy<Value = usize> + Clone,
+    ) -> impl Strategy<Value = Operation<G::Value>>
     where
         G::Value: Clone + 'static,
     {
-        let append_count = optypes
-            .iter()
-            .filter(|t| matches!(t, OpType::Append))
-            .count();
-        proptest::collection::vec(item_gen, append_count + 1)
-            .prop_flat_map(move |items: Vec<G::Value>| arb_operations_0(optypes.clone(), items))
-    }
-
-    pub fn arb_operations<G: Strategy + Clone>(
-        item_gen: G,
-        count: impl Into<SizeRange>,
-    ) -> impl Strategy<Value = Vec<Operation<G::Value>>>
-    where
-        G::Value: Clone + 'static,
-    {
-        proptest::collection::vec(
-            select(vec![
-                OpType::Append,
-                OpType::Witness,
-                OpType::Unwitness,
-                OpType::Checkpoint,
-                OpType::Rewind,
-                OpType::Authpath,
-            ]),
-            count,
-        )
-        .prop_flat_map(move |optypes: Vec<OpType>| arb_operations_1(item_gen.clone(), optypes))
+        prop_oneof![
+            item_gen.prop_map(Operation::Append),
+            Just(Operation::CurrentLeaf),
+            Just(Operation::CurrentPosition),
+            Just(Operation::Witness),
+            pos_gen
+                .clone()
+                .prop_map(|i| Operation::WitnessedLeaf(Position::from(i))),
+            pos_gen
+                .clone()
+                .prop_map(|i| Operation::Unwitness(Position::from(i))),
+            Just(Operation::Checkpoint),
+            Just(Operation::Rewind),
+            pos_gen.prop_map(|i| Operation::Authpath(Position::from(i))),
+        ]
     }
 
     pub fn apply_operation<H, T: Tree<H>>(tree: &mut T, op: Operation<H>) {
@@ -1053,8 +998,8 @@ pub(crate) mod tests {
             Witness => {
                 tree.witness();
             }
-            Unwitness(position, value) => {
-                tree.remove_witness(position, &value);
+            Unwitness(position) => {
+                tree.remove_witness(position);
             }
             Checkpoint => {
                 tree.checkpoint();
@@ -1062,7 +1007,10 @@ pub(crate) mod tests {
             Rewind => {
                 tree.rewind();
             }
-            Authpath(_, _) => {}
+            CurrentPosition => {}
+            CurrentLeaf => {}
+            Authpath(_) => {}
+            WitnessedLeaf(_) => {}
         }
     }
 
@@ -1073,7 +1021,7 @@ pub(crate) mod tests {
         let mut tree = CombinedTree::<H, DEPTH>::new();
 
         let mut tree_size = 0;
-        let mut tree_values = vec![];
+        let mut tree_values: Vec<H> = vec![];
         // the number of leaves in the tree at the time that a checkpoint is made
         let mut tree_checkpoints: Vec<usize> = vec![];
 
@@ -1089,6 +1037,15 @@ pub(crate) mod tests {
                         prop_assert_eq!(tree_size, 1 << DEPTH);
                     }
                 }
+                CurrentPosition => {
+                    if let Some(pos) = tree.current_position() {
+                        prop_assert!(tree_size > 0);
+                        prop_assert_eq!(tree_size - 1, pos.into());
+                    }
+                }
+                CurrentLeaf => {
+                    prop_assert_eq!(tree_values.last(), tree.current_leaf());
+                }
                 Witness => {
                     if tree.witness().is_some() {
                         prop_assert!(tree_size != 0);
@@ -1096,8 +1053,13 @@ pub(crate) mod tests {
                         prop_assert_eq!(tree_size, 0);
                     }
                 }
-                Unwitness(position, value) => {
-                    tree.remove_witness(position, &value);
+                WitnessedLeaf(position) => {
+                    if tree.get_witnessed_leaf(position).is_some() {
+                        prop_assert!(<usize>::from(position) < tree_size);
+                    }
+                }
+                Unwitness(position) => {
+                    tree.remove_witness(position);
                 }
                 Checkpoint => {
                     tree_checkpoints.push(tree_size);
@@ -1111,8 +1073,9 @@ pub(crate) mod tests {
                         tree_size = checkpointed_tree_size;
                     }
                 }
-                Authpath(position, value) => {
-                    if let Some(path) = tree.authentication_path(position, &value) {
+                Authpath(position) => {
+                    if let Some(path) = tree.authentication_path(position) {
+                        let value: H = tree_values.get(<usize>::from(position)).unwrap().clone();
                         let mut extended_tree_values = tree_values.clone();
                         extended_tree_values.resize(1 << DEPTH, H::empty_leaf());
                         let expected_root = lazy_root::<H>(extended_tree_values);
@@ -1137,14 +1100,20 @@ pub(crate) mod tests {
 
         #[test]
         fn check_randomized_u64_ops(
-            ops in arb_operations((0..32u64).prop_map(SipHashable), 1..100)
+            ops in proptest::collection::vec(
+                arb_operation((0..32u64).prop_map(SipHashable), 0usize..100),
+                1..100
+            )
         ) {
             check_operations(ops)?;
         }
 
         #[test]
         fn check_randomized_str_ops(
-            ops in arb_operations((97u8..123).prop_map(|c| char::from(c).to_string()), 1..100)
+            ops in proptest::collection::vec(
+                arb_operation((97u8..123).prop_map(|c| char::from(c).to_string()), 0usize..100),
+                1..100
+            )
         ) {
             check_operations::<String>(ops)?;
         }

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,11 +1,12 @@
 //! Sample implementation of the Tree interface.
 use super::{Altitude, Frontier, Hashable, Position, Tree};
+use std::collections::BTreeSet;
 
 #[derive(Clone, Debug)]
 pub struct TreeState<H: Hashable> {
     leaves: Vec<H>,
     current_offset: usize,
-    witnesses: Vec<(Position, H)>,
+    witnesses: BTreeSet<Position>,
     depth: usize,
 }
 
@@ -16,7 +17,7 @@ impl<H: Hashable + Clone> TreeState<H> {
         Self {
             leaves: vec![H::empty_leaf(); 1 << depth],
             current_offset: 0,
-            witnesses: vec![],
+            witnesses: BTreeSet::new(),
             depth,
         }
     }
@@ -51,68 +52,59 @@ impl<H: Hashable + PartialEq + Clone> TreeState<H> {
     }
 
     /// Returns the leaf most recently appended to the tree
-    fn current_leaf(&self) -> Option<(Position, H)> {
+    fn current_leaf(&self) -> Option<&H> {
         self.current_position()
-            .map(|p| (p, self.leaves[<usize>::from(p)].clone()))
+            .map(|p| &self.leaves[<usize>::from(p)])
     }
 
     /// Returns whether a leaf with the specified position and value has been witnessed
-    fn is_witnessed(&self, position: Position, value: &H) -> bool {
-        self.witnesses
-            .iter()
-            .any(|(pos, v)| pos == &position && v == value)
+    fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
+        if self.witnesses.contains(&position) {
+            self.leaves.get(<usize>::from(position))
+        } else {
+            None
+        }
     }
 
     /// Marks the current tree state leaf as a value that we're interested in
     /// witnessing. Returns the current position and leaf value if the tree
     /// is non-empty.
-    fn witness(&mut self) -> Option<(Position, H)> {
-        self.current_leaf().map(|(pos, value)| {
-            if !self.is_witnessed(pos, &value) {
-                self.witnesses.push((pos, value.clone()));
+    fn witness(&mut self) -> Option<Position> {
+        self.current_position().map(|pos| {
+            if !self.witnesses.contains(&pos) {
+                self.witnesses.insert(pos);
             }
-            (pos, value)
+            pos
         })
     }
 
     /// Obtains an authentication path to the value specified in the tree.
     /// Returns `None` if there is no available authentication path to the
     /// specified value.
-    fn authentication_path(&self, position: Position, value: &H) -> Option<Vec<H>> {
-        self.witnesses
-            .iter()
-            .find(|(pos, v)| pos == &position && v == value)
-            .map(|_| {
-                let mut path = vec![];
+    fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
+        if self.witnesses.contains(&position) {
+            let mut path = vec![];
 
-                let mut leaf_idx: usize = position.into();
-                for bit in 0..self.depth {
-                    leaf_idx ^= 1 << bit;
-                    path.push(lazy_root::<H>(
-                        self.leaves[leaf_idx..][0..(1 << bit)].to_vec(),
-                    ));
-                    leaf_idx &= usize::MAX << (bit + 1);
-                }
+            let mut leaf_idx: usize = position.into();
+            for bit in 0..self.depth {
+                leaf_idx ^= 1 << bit;
+                path.push(lazy_root::<H>(
+                    self.leaves[leaf_idx..][0..(1 << bit)].to_vec(),
+                ));
+                leaf_idx &= usize::MAX << (bit + 1);
+            }
 
-                path
-            })
+            Some(path)
+        } else {
+            None
+        }
     }
 
     /// Marks the specified tree state value as a value we're no longer
     /// interested in maintaining a witness for. Returns true if successful and
     /// false if the value is not a known witness.
-    fn remove_witness(&mut self, position: Position, value: &H) -> bool {
-        if let Some((witness_index, _)) = self
-            .witnesses
-            .iter()
-            .enumerate()
-            .find(|(_i, (pos, v))| pos == &position && v == value)
-        {
-            self.witnesses.remove(witness_index);
-            true
-        } else {
-            false
-        }
+    fn remove_witness(&mut self, position: Position) -> bool {
+        self.witnesses.remove(&position)
     }
 }
 
@@ -168,34 +160,34 @@ impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
     }
 
     /// Returns the leaf most recently appended to the tree
-    fn current_leaf(&self) -> Option<(Position, H)> {
+    fn current_leaf(&self) -> Option<&H> {
         self.tree_state.current_leaf()
     }
 
     /// Returns whether a leaf with the specified value has been witnessed
-    fn is_witnessed(&self, position: Position, value: &H) -> bool {
-        self.tree_state.is_witnessed(position, value)
+    fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
+        self.tree_state.get_witnessed_leaf(position)
     }
 
     /// Marks the current tree state leaf as a value that we're interested in
     /// witnessing. Returns the current position and leaf value if the tree
     /// is non-empty.
-    fn witness(&mut self) -> Option<(Position, H)> {
+    fn witness(&mut self) -> Option<Position> {
         self.tree_state.witness()
     }
 
     /// Obtains an authentication path to the value specified in the tree.
     /// Returns `None` if there is no available authentication path to the
     /// specified value.
-    fn authentication_path(&self, position: Position, value: &H) -> Option<Vec<H>> {
-        self.tree_state.authentication_path(position, value)
+    fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
+        self.tree_state.authentication_path(position)
     }
 
     /// Marks the specified tree state value as a value we're no longer
     /// interested in maintaining a witness for. Returns true if successful and
     /// false if the value is not a known witness.
-    fn remove_witness(&mut self, position: Position, value: &H) -> bool {
-        self.tree_state.remove_witness(position, value)
+    fn remove_witness(&mut self, position: Position) -> bool {
+        self.tree_state.remove_witness(position)
     }
 
     /// Marks the current tree state as a checkpoint if it is not already a
@@ -331,7 +323,7 @@ mod tests {
 
         for i in 0u64..(1 << DEPTH) {
             let position = Position::try_from(i).unwrap();
-            let path = tree.authentication_path(position, &SipHashable(i)).unwrap();
+            let path = tree.authentication_path(position).unwrap();
             assert_eq!(
                 compute_root_from_auth_path(SipHashable(i), position, &path),
                 expected

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -24,8 +24,6 @@ impl<H: Hashable + Clone> TreeState<H> {
 }
 
 impl<H: Hashable + Clone> Frontier<H> for TreeState<H> {
-    /// Appends a new value to the tree at the next available slot. Returns true
-    /// if successful and false if the tree is full.
     fn append(&mut self, value: &H) -> bool {
         if self.current_offset == (1 << self.depth) {
             false
@@ -128,13 +126,10 @@ impl<H: Hashable + Clone> CompleteTree<H> {
 }
 
 impl<H: Hashable + Clone> Frontier<H> for CompleteTree<H> {
-    /// Appends a new value to the tree at the next available slot. Returns true
-    /// if successful and false if the tree is full.
     fn append(&mut self, value: &H) -> bool {
         self.tree_state.append(value)
     }
 
-    /// Obtains the current root of this Merkle tree.
     fn root(&self) -> H {
         self.tree_state.root()
     }
@@ -154,44 +149,30 @@ impl<H: Hashable + PartialEq + Clone> CompleteTree<H> {
 }
 
 impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
-    /// Returns the most recently appended leaf value.
     fn current_position(&self) -> Option<Position> {
         self.tree_state.current_position()
     }
 
-    /// Returns the leaf most recently appended to the tree
     fn current_leaf(&self) -> Option<&H> {
         self.tree_state.current_leaf()
     }
 
-    /// Returns the leaf at the specified position if the tree can produce
-    /// an authentication path for it.
     fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
         self.tree_state.get_witnessed_leaf(position)
     }
 
-    /// Marks the current tree state leaf as a value that we're interested in
-    /// witnessing. Returns the current position if the tree is non-empty.
     fn witness(&mut self) -> Option<Position> {
         self.tree_state.witness()
     }
 
-    /// Obtains an authentication path to the value at the specified position.
-    /// Returns `None` if there is no available authentication path to that
-    /// value.
     fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
         self.tree_state.authentication_path(position)
     }
 
-    /// Marks the value at the specified position as a value we're no longer
-    /// interested in maintaining a witness for. Returns true if successful and
-    /// false if we were already not maintaining a witness at this position.
     fn remove_witness(&mut self, position: Position) -> bool {
         self.tree_state.remove_witness(position)
     }
 
-    /// Marks the current tree state as a checkpoint if it is not already a
-    /// checkpoint.
     fn checkpoint(&mut self) {
         self.checkpoints.push(self.tree_state.clone());
         if self.checkpoints.len() > self.max_checkpoints {
@@ -199,8 +180,6 @@ impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
         }
     }
 
-    /// Rewinds the tree state to the previous checkpoint. This function will
-    /// return false and leave the tree unmodified if no checkpoints exist.
     fn rewind(&mut self) -> bool {
         if let Some(checkpointed_state) = self.checkpoints.pop() {
             self.tree_state = checkpointed_state;

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -57,7 +57,8 @@ impl<H: Hashable + PartialEq + Clone> TreeState<H> {
             .map(|p| &self.leaves[<usize>::from(p)])
     }
 
-    /// Returns whether a leaf with the specified position and value has been witnessed
+    /// Returns the leaf at the specified position if the tree can produce
+    /// an authentication path for it.
     fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
         if self.witnesses.contains(&position) {
             self.leaves.get(<usize>::from(position))
@@ -67,8 +68,7 @@ impl<H: Hashable + PartialEq + Clone> TreeState<H> {
     }
 
     /// Marks the current tree state leaf as a value that we're interested in
-    /// witnessing. Returns the current position and leaf value if the tree
-    /// is non-empty.
+    /// witnessing. Returns the current position if the tree is non-empty.
     fn witness(&mut self) -> Option<Position> {
         self.current_position().map(|pos| {
             if !self.witnesses.contains(&pos) {
@@ -78,9 +78,9 @@ impl<H: Hashable + PartialEq + Clone> TreeState<H> {
         })
     }
 
-    /// Obtains an authentication path to the value specified in the tree.
-    /// Returns `None` if there is no available authentication path to the
-    /// specified value.
+    /// Obtains an authentication path to the value at the specified position.
+    /// Returns `None` if there is no available authentication path to that
+    /// value.
     fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
         if self.witnesses.contains(&position) {
             let mut path = vec![];
@@ -100,9 +100,9 @@ impl<H: Hashable + PartialEq + Clone> TreeState<H> {
         }
     }
 
-    /// Marks the specified tree state value as a value we're no longer
+    /// Marks the value at the specified position as a value we're no longer
     /// interested in maintaining a witness for. Returns true if successful and
-    /// false if the value is not a known witness.
+    /// false if we were already not maintaining a witness at this position.
     fn remove_witness(&mut self, position: Position) -> bool {
         self.witnesses.remove(&position)
     }
@@ -164,28 +164,28 @@ impl<H: Hashable + PartialEq + Clone> Tree<H> for CompleteTree<H> {
         self.tree_state.current_leaf()
     }
 
-    /// Returns whether a leaf with the specified value has been witnessed
+    /// Returns the leaf at the specified position if the tree can produce
+    /// an authentication path for it.
     fn get_witnessed_leaf(&self, position: Position) -> Option<&H> {
         self.tree_state.get_witnessed_leaf(position)
     }
 
     /// Marks the current tree state leaf as a value that we're interested in
-    /// witnessing. Returns the current position and leaf value if the tree
-    /// is non-empty.
+    /// witnessing. Returns the current position if the tree is non-empty.
     fn witness(&mut self) -> Option<Position> {
         self.tree_state.witness()
     }
 
-    /// Obtains an authentication path to the value specified in the tree.
-    /// Returns `None` if there is no available authentication path to the
-    /// specified value.
+    /// Obtains an authentication path to the value at the specified position.
+    /// Returns `None` if there is no available authentication path to that
+    /// value.
     fn authentication_path(&self, position: Position) -> Option<Vec<H>> {
         self.tree_state.authentication_path(position)
     }
 
-    /// Marks the specified tree state value as a value we're no longer
+    /// Marks the value at the specified position as a value we're no longer
     /// interested in maintaining a witness for. Returns true if successful and
-    /// false if the value is not a known witness.
+    /// false if we were already not maintaining a witness at this position.
     fn remove_witness(&mut self, position: Position) -> bool {
         self.tree_state.remove_witness(position)
     }


### PR DESCRIPTION
    Always query the tree by position, not hash.

    This modifies the `Tree::authentication_path` and `Tree::remove_witness`
    methods to only operate in terms of the tree position, rather than both
    the position and the hash that is expected to be the leaf at that
    position.

    Positions in the tree are always unique, and the tree already contains
    the leaf information corresponding to each position, so the existing API
    previously required the storage of redundant information. This change
    streamlines the API without loss of power.

    This also adds additional consistency checks to the property tests.