### PR TITLE
Add conversions from incrementalmerkletree types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ categories = ["algorithms", "data-structures"]
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 proptest = { version = "1.0.0", optional = true }
+incrementalmerkletree = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 proptest = "1.0.0"
 
 [features]
+incrementalmerkletree-compat = ["incrementalmerkletree"]
 test-dependencies = ["proptest"]

--- a/src/position.rs
+++ b/src/position.rs
@@ -35,14 +35,28 @@ impl From<u8> for Level {
 }
 
 impl From<Level> for u8 {
-    fn from(level: Level) -> u8 {
+    fn from(level: Level) -> Self {
         level.0
     }
 }
 
 impl From<Level> for usize {
-    fn from(level: Level) -> usize {
+    fn from(level: Level) -> Self {
         level.0 as usize
+    }
+}
+
+#[cfg(feature = "incrementalmerkletree-compat")]
+impl From<Level> for incrementalmerkletree::Altitude {
+    fn from(level: Level) -> Self {
+        incrementalmerkletree::Altitude::from(level.0)
+    }
+}
+
+#[cfg(feature = "incrementalmerkletree-compat")]
+impl From<incrementalmerkletree::Altitude> for Level {
+    fn from(altitude: incrementalmerkletree::Altitude) -> Self {
+        Level(altitude.into())
     }
 }
 
@@ -95,7 +109,7 @@ impl Position {
 }
 
 impl From<Position> for usize {
-    fn from(p: Position) -> usize {
+    fn from(p: Position) -> Self {
         p.0
     }
 }
@@ -129,6 +143,13 @@ impl TryFrom<u64> for Position {
     type Error = TryFromIntError;
     fn try_from(sz: u64) -> Result<Self, Self::Error> {
         <usize>::try_from(sz).map(Self)
+    }
+}
+
+#[cfg(feature = "incrementalmerkletree-compat")]
+impl From<incrementalmerkletree::Position> for Position {
+    fn from(position: incrementalmerkletree::Position) -> Self {
+        Self(position.into())
     }
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -650,7 +650,7 @@ pub(crate) mod tests {
     #[derive(Clone)]
     pub struct CombinedTree<H: Hashable + Ord, const DEPTH: u8> {
         inefficient: CompleteTree<H>,
-        efficient: BridgeTree<H, DEPTH>,
+        efficient: BridgeTree<H, (), DEPTH>,
     }
 
     impl<H: Hashable + Ord + Clone, const DEPTH: u8> CombinedTree<H, DEPTH> {
@@ -731,7 +731,7 @@ pub(crate) mod tests {
 
         fn checkpoint(&mut self) {
             self.inefficient.checkpoint();
-            self.efficient.checkpoint();
+            self.efficient.checkpoint(());
         }
 
         fn rewind(&mut self) -> bool {


### PR DESCRIPTION
A new feature flag, `incrementalmerkletree-compat` is introduced.
This flag guards a set of conversions from `incrementalmerkletree`
types to `bridgetree` types to facilitate updating to `bridgetree`
from `incrementalmerkletree`.