### PR TITLE
Make it possible to tag checkpoints with identifying information.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1554,4 +1554,15 @@ mod tests {
         tree.rewind();
         assert!(tree.root(0) != empty_root);
     }
+
+    #[test]
+    fn checkpoint_ids() {
+        let mut tree: BridgeTree<String, u32, 7> = BridgeTree::new(100);
+        tree.append(&"a".to_string());
+        for i in 0u32..100 {
+            assert!(tree.append(&format!("{}", i)));
+            tree.checkpoint(i);
+        }
+        assert_eq!(tree.last_checkpoint_id(), Some(&99));
+    }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -650,7 +650,7 @@ pub(crate) mod tests {
     #[derive(Clone)]
     pub struct CombinedTree<H: Hashable + Ord, const DEPTH: u8> {
         inefficient: CompleteTree<H>,
-        efficient: BridgeTree<H, DEPTH>,
+        efficient: BridgeTree<H, (), DEPTH>,
     }
 
     impl<H: Hashable + Ord + Clone, const DEPTH: u8> CombinedTree<H, DEPTH> {
@@ -731,7 +731,7 @@ pub(crate) mod tests {
 
         fn checkpoint(&mut self) {
             self.inefficient.checkpoint();
-            self.efficient.checkpoint();
+            self.efficient.checkpoint(());
         }
 
         fn rewind(&mut self) -> bool {


### PR DESCRIPTION
When restoring bridgetree information from persistent data, it
is often useful and/or necessary to be able to validate the state
of the returned data against other information in the system that
is using the tree. An easy way to do this is to add identifying
information to each checkpoint so that it can be compared to the
state of the system that might otherwise need to make dangerous
assumptions about the state of the tree as of a given checkpoint.