### PR TITLE
Add `Address` methods to facilitate tree traversal.

### DIFF
--- a/bridgetree/src/lib.rs
+++ b/bridgetree/src/lib.rs
@@ -109,7 +109,7 @@ impl Iterator for WitnessAddrsIter {
     fn next(&mut self) -> Option<(Address, Source)> {
         if self.current.level() < self.root_level {
             let current = self.current;
-            let source = if current.is_complete_node() {
+            let source = if current.is_right_child() {
                 Source::Past(self.ommer_count)
             } else {
                 Source::Future

--- a/incrementalmerkletree/src/lib.rs
+++ b/incrementalmerkletree/src/lib.rs
@@ -1,9 +1,11 @@
 //! Common types and utilities used in incremental Merkle tree implementations.
 
+use either::Either;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::convert::{TryFrom, TryInto};
 use std::num::TryFromIntError;
-use std::ops::{Add, AddAssign, Range};
+use std::ops::{Add, AddAssign, Range, Sub};
 
 #[cfg(feature = "test-dependencies")]
 pub mod testing;
@@ -66,6 +68,16 @@ impl AddAssign<usize> for Position {
     }
 }
 
+impl Sub<usize> for Position {
+    type Output = Position;
+    fn sub(self, other: usize) -> Self {
+        if self.0 < other {
+            panic!("position underflow");
+        }
+        Position(self.0 - other)
+    }
+}
+
 impl From<usize> for Position {
     fn from(sz: usize) -> Self {
         Self(sz)
@@ -120,6 +132,16 @@ impl From<Level> for usize {
     }
 }
 
+impl Sub<u8> for Level {
+    type Output = Self;
+    fn sub(self, value: u8) -> Self {
+        if self.0 < value {
+            panic!("underflow")
+        }
+        Self(self.0 - value)
+    }
+}
+
 /// The address of an internal node of the Merkle tree.
 /// When `level == 0`, the index has the same value as the
 /// position.
@@ -130,25 +152,35 @@ pub struct Address {
 }
 
 impl Address {
+    /// Construct a new address from its constituent parts.
     pub fn from_parts(level: Level, index: usize) -> Self {
         Address { level, index }
     }
 
-    pub fn position_range(&self) -> Range<Position> {
-        Range {
-            start: (self.index << self.level.0).try_into().unwrap(),
-            end: ((self.index + 1) << self.level.0).try_into().unwrap(),
+    /// Returns the address at the given level that contains the specified leaf position.
+    pub fn above_position(level: Level, position: Position) -> Self {
+        Address {
+            level,
+            index: position.0 >> level.0,
         }
     }
 
+    /// Returns the level of the root of the tree having its root at this address.
     pub fn level(&self) -> Level {
         self.level
     }
 
+    /// Returns the index of the address.
+    ///
+    /// The index of an address is defined as the number of subtrees with their roots
+    /// at the address's level that appear to the left of this address in a binary
+    /// tree of arbitrary height > level * 2 + 1.
     pub fn index(&self) -> usize {
         self.index
     }
 
+    /// The address of the node one level higher than this in a binary tree that contains
+    /// this address as either its left or right child.
     pub fn parent(&self) -> Address {
         Address {
             level: self.level + 1,
@@ -156,6 +188,7 @@ impl Address {
         }
     }
 
+    /// Returns the address that shares the same parent as this address.
     pub fn sibling(&self) -> Address {
         Address {
             level: self.level,
@@ -167,7 +200,98 @@ impl Address {
         }
     }
 
-    pub fn is_complete_node(&self) -> bool {
+    /// Returns the immediate children of this address.
+    pub fn children(&self) -> Option<(Address, Address)> {
+        if self.level == Level::from(0) {
+            None
+        } else {
+            let left = Address {
+                level: self.level - 1,
+                index: self.index << 1,
+            };
+
+            let right = Address {
+                level: self.level - 1,
+                index: (self.index << 1) + 1,
+            };
+
+            Some((left, right))
+        }
+    }
+
+    /// Returns whether this address is an ancestor of the specified address.
+    pub fn is_ancestor_of(&self, addr: &Self) -> bool {
+        self.level > addr.level && { addr.index >> (self.level.0 - addr.level.0) == self.index }
+    }
+
+    /// Returns whether this address is an ancestor of, or is equal to,
+    /// the specified address.
+    pub fn contains(&self, addr: &Self) -> bool {
+        self == addr || self.is_ancestor_of(addr)
+    }
+
+    /// Returns the minimum value among the range of leaf positions that are contained within the
+    /// tree with its root at this address.
+    pub fn position_range_start(&self) -> Position {
+        (self.index << self.level.0).try_into().unwrap()
+    }
+
+    /// Returns the (exclusive) end of the range of leaf positions that are contained within the
+    /// tree with its root at this address.
+    pub fn position_range_end(&self) -> Position {
+        ((self.index + 1) << self.level.0).try_into().unwrap()
+    }
+
+    /// Returns the maximum value among the range of leaf positions that are contained within the
+    /// tree with its root at this address.
+    pub fn max_position(&self) -> Position {
+        self.position_range_end() - 1
+    }
+
+    /// Returns the end-exclusive range of leaf positions that are contained within the tree with
+    /// its root at this address.
+    pub fn position_range(&self) -> Range<Position> {
+        Range {
+            start: self.position_range_start(),
+            end: self.position_range_end(),
+        }
+    }
+
+    /// Returns either the ancestor of this address at the given level (if the level is greater
+    /// than or equal to that of this address) or the range of indices of root addresses of
+    /// subtrees with roots at the given level contained within the tree with its root at this
+    /// address otherwise.
+    pub fn context(&self, level: Level) -> Either<Address, Range<usize>> {
+        if level >= self.level {
+            Either::Left(Address {
+                level,
+                index: self.index >> (level.0 - self.level.0),
+            })
+        } else {
+            let shift = self.level.0 - level.0;
+            Either::Right(Range {
+                start: self.index << shift,
+                end: (self.index + 1) << shift,
+            })
+        }
+    }
+
+    /// Returns whether the tree with this root address contains the given leaf position, or if not
+    /// whether an address at the same level with a greater or lesser index will contain the
+    /// specified leaf position.
+    pub fn position_cmp(&self, pos: Position) -> Ordering {
+        let range = self.position_range();
+        if range.start > pos {
+            Ordering::Greater
+        } else if range.end <= pos {
+            Ordering::Less
+        } else {
+            Ordering::Equal
+        }
+    }
+
+    /// Returns whether this address is the right-hand child of its parent
+    pub fn is_right_child(&self) -> bool {
         self.index & 0x1 == 1
     }
 
@@ -189,7 +313,7 @@ impl Address {
     }
 
     pub fn next_incomplete_parent(&self) -> Address {
-        if self.is_complete_node() {
+        if self.is_right_child() {
             self.current_incomplete()
         } else {
             let complete = Address {
@@ -197,6 +321,14 @@ impl Address {
                 index: self.index + 1,
             };
             complete.current_incomplete()
+        }
+    }
+
+    /// Increments this address's index by 1 and returns the resulting address.
+    pub fn next_at_level(&self) -> Address {
+        Address {
+            level: self.level,
+            index: self.index + 1,
         }
     }
 }
@@ -256,6 +388,8 @@ pub trait Hashable: Sized {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::{Address, Level, Position};
+    use core::ops::Range;
+    use either::Either;
 
     #[test]
     fn position_is_complete_subtree() {
@@ -310,5 +444,80 @@ pub(crate) mod tests {
         assert_eq!(addr(3, 0), addr(2, 0).next_incomplete_parent());
         assert_eq!(addr(1, 2), addr(0, 4).next_incomplete_parent());
         assert_eq!(addr(3, 0), addr(1, 2).next_incomplete_parent());
+    }
+
+    #[test]
+    fn addr_is_ancestor() {
+        let l0 = Level(0);
+        let l1 = Level(1);
+        assert!(Address::from_parts(l1, 0).is_ancestor_of(&Address::from_parts(l0, 0)));
+        assert!(Address::from_parts(l1, 0).is_ancestor_of(&Address::from_parts(l0, 1)));
+        assert!(!Address::from_parts(l1, 0).is_ancestor_of(&Address::from_parts(l0, 2)));
+    }
+
+    #[test]
+    fn addr_position_range() {
+        assert_eq!(
+            Address::from_parts(Level(0), 0).position_range(),
+            Range {
+                start: Position(0),
+                end: Position(1)
+            }
+        );
+        assert_eq!(
+            Address::from_parts(Level(1), 0).position_range(),
+            Range {
+                start: Position(0),
+                end: Position(2)
+            }
+        );
+        assert_eq!(
+            Address::from_parts(Level(2), 1).position_range(),
+            Range {
+                start: Position(4),
+                end: Position(8)
+            }
+        );
+    }
+
+    #[test]
+    fn addr_above_position() {
+        assert_eq!(
+            Address::above_position(Level(3), Position(9)),
+            Address::from_parts(Level(3), 1)
+        );
+    }
+
+    #[test]
+    fn addr_children() {
+        assert_eq!(Address::from_parts(Level(0), 1).children(), None);
+
+        assert_eq!(
+            Address::from_parts(Level(3), 1).children(),
+            Some((
+                Address::from_parts(Level(2), 2),
+                Address::from_parts(Level(2), 3),
+            ))
+        );
+    }
+
+    #[test]
+    fn addr_is_ancestor_of() {
+        assert!(Address::from_parts(Level(3), 1).is_ancestor_of(&Address::from_parts(Level(2), 2)));
+        assert!(Address::from_parts(Level(3), 1).is_ancestor_of(&Address::from_parts(Level(1), 7)));
+        assert!(!Address::from_parts(Level(3), 1).is_ancestor_of(&Address::from_parts(Level(1), 8)));
+    }
+
+    #[test]
+    fn addr_context() {
+        assert_eq!(
+            Address::from_parts(Level(3), 1).context(Level(0)),
+            Either::Right(Range { start: 8, end: 16 })
+        );
+
+        assert_eq!(
+            Address::from_parts(Level(3), 4).context(Level(5)),
+            Either::Left(Address::from_parts(Level(5), 1))
+        );
     }
 }


### PR DESCRIPTION
This commit was extracted from the `shardtree` branch to allow updates to `librustzcash` prior to the `shardtree` merge.