### PR TITLE
Update MSRV to 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run tests
-        run: cargo test --all-features --verbose --release --all
+        run: cargo test --all-features --verbose --workspace
       - name: Verify working directory is clean
         run: git diff --exit-code
 
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
-        run: cargo build --all --benches
+        run: cargo build --workspace --benches
 
   doc-links:
     name: Intra-doc links
@@ -33,7 +33,7 @@ jobs:
       - run: cargo fetch
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
-        run: cargo doc --all --document-private-items
+        run: cargo doc --workspace --document-private-items
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,71 +9,37 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.1
-          override: true
+      - uses: actions/checkout@v3
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --all-features --verbose --release --all
+      - name: Verify working directory is clean
+        run: git diff --exit-code
 
   bitrot:
     name: Bitrot check
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.1
-          override: true
+      - uses: actions/checkout@v3
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --benches
+        run: cargo build --all --benches
 
   doc-links:
     name: Intra-doc links
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.1
-          override: true
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-
-      # Ensure intra-documentation links all resolve correctly
-      # Requires #![deny(intra_doc_link_resolution_failure)] in crates.
+      - uses: actions/checkout@v3
+      - run: cargo fetch
+      # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --document-private-items
+        run: cargo doc --all --document-private-items
 
   fmt:
     name: Rustfmt
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.1
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+      - uses: actions/checkout@v3
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/.github/workflows/lints-beta.yml
+++ b/.github/workflows/lints-beta.yml
@@ -10,17 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          components: clippy
-          override: true
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@beta
+        id: toolchain
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Run Clippy (beta)
         uses: actions-rs/clippy-check@v1
         continue-on-error: true
         with:
           name: Clippy (beta)
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
-
+          args: --all-features --all-targets -- -W clippy::all

--- a/.github/workflows/lints-stable.yml
+++ b/.github/workflows/lints-stable.yml
@@ -5,19 +5,14 @@ on: pull_request
 
 jobs:
   clippy:
-    name: Clippy (1.56.1)
+    name: Clippy (MSRV)
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.1
-          components: clippy
-          override: true
-      - name: Run Clippy
+      - uses: actions/checkout@v3
+      - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
-          name: Clippy (1.56.1)
+          name: Clippy (MSRV)
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings

--- a/bridgetree/Cargo.toml
+++ b/bridgetree/Cargo.toml
@@ -5,12 +5,13 @@ authors = [
     "Kris Nuttycombe <kris@nutty.land>",
     "Sean Bowe <ewillbefull@gmail.com>",
 ]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A space-efficient Merkle tree designed for linear appends with witnessing of marked leaves, checkpointing & state restoration."
 homepage = "https://github.com/zcash/incrementalmerkletree"
 repository = "https://github.com/zcash/incrementalmerkletree"
 categories = ["algorithms", "data-structures"]
+rust-version = "1.60"
 
 [dependencies]
 incrementalmerkletree = { version = "0.3", path = "../incrementalmerkletree" }

--- a/incrementalmerkletree/Cargo.toml
+++ b/incrementalmerkletree/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "incrementalmerkletree"
+description = "Common types, interfaces, and utilities for Merkle tree data structures"
 version = "0.3.0"
 authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
     "Kris Nuttycombe <kris@nutty.land>",
 ]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
-description = "Common types, interfaces, and utilities for Merkle tree data structures"
 homepage = "https://github.com/zcash/incrementalmerkletree"
 repository = "https://github.com/zcash/incrementalmerkletree"
 categories = ["algorithms", "data-structures"]
+rust-version = "1.60"
 
 [dependencies]
 either = "1.8"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.60.0"
+components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
The transitive dependency we have on `unarray` is forcing this update. Also, update CI actions to eliminate dependencies on the unmaintained `actions-rs` Rust CI tools.