### PR TITLE
[0.3.1] Fix a bug on 32-bit platforms that caused `Position::max_altitude` to return the wrong value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Fixed
+
+- A bug affecting 32-bit platforms caused `Position::max_altitude` to return the wrong
+  value. This typically manifested as failures to add commitments to the tree.
+
 ## [0.3.0] - 2022-05-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ categories = ["algorithms", "data-structures"]
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-proptest = "1"
+proptest = "~1.0"

--- a/proptest-regressions/lib.txt
+++ b/proptest-regressions/lib.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 713580b935d97377d97711c7f126ad2ef82c961bc4b64b538c551d1b2e8b1cdb # shrinks to ops = [Append("a"), Append("a"), Append("a")]
+cc db0c5a37f69e8824f0680d595aaf803e15b207d5571d07db464d8178037d8798 # shrinks to ops = [Append(SipHashable(0)), Append(SipHashable(0)), Authpath(Position(0), 0)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ impl Position {
         Altitude(if self.0 == 0 {
             0
         } else {
-            63 - self.0.leading_zeros() as u8
+            (usize::BITS - 1 - self.0.leading_zeros()) as u8
         })
     }
 


### PR DESCRIPTION
fixes #56