### PR TITLE
Fix a bug on 32-bit platforms that caused `Position::root_level` to return the wrong value

### DIFF
--- a/bridgetree/proptest-regressions/lib.txt
+++ b/bridgetree/proptest-regressions/lib.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 190d23d28fc081e651e779d6209951363ee8a21752233cb72471626d14dd8bad # shrinks to ops = [Append("a"), Append("a"), Append("a")]
+cc 81533fad8faadbdfdc9547e07f0491e40172a2f5fe4e8768d289389ed2e3cbcb # shrinks to ops = [Append(SipHashable(0)), Append(SipHashable(0)), Append(SipHashable(0))]

--- a/incrementalmerkletree/CHANGELOG.md
+++ b/incrementalmerkletree/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Fixed
+
+- A bug affecting 32-bit platforms caused `Position::max_altitude` (which has
+  been renamed to `Position::root_level`) to return the wrong value. This
+  typically manifested as failures to add commitments to the tree.
+
 ### Added
 
 - `Position::is_odd`

--- a/incrementalmerkletree/src/lib.rs
+++ b/incrementalmerkletree/src/lib.rs
@@ -24,7 +24,7 @@ impl Position {
     /// Returns the minimum possible level of the root of a binary tree containing at least
     /// `self + 1` nodes.
     pub fn root_level(&self) -> Level {
-        Level(64 - self.0.leading_zeros() as u8)
+        Level((usize::BITS - self.0.leading_zeros()) as u8)
     }
 
     /// Returns the number of cousins and/or ommers required to construct an authentication


### PR DESCRIPTION
fixes #56