### PR TITLE
Release of `bridgetree` v0.2.1

### DIFF
--- a/bridgetree/CHANGELOG.md
+++ b/bridgetree/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [bridgetree-v0.2.1] - 2023-06-05
+
+This release has no known changes from `bridgetree-v0.2.0`. It exists because
+the source code used for the `bridgetree-v0.2.0` release was not properly
+persisted and tagged in the source repository at the time that the release was
+made, and as a consequence the `bridgetree-v0.2.0` release has been yanked.
+
 ## [bridgetree-v0.2.0] - 2022-05-10
 
 The `bridgetree` crate is a fork of `incrementalmerkletree`, with the contents

--- a/bridgetree/Cargo.toml
+++ b/bridgetree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridgetree"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Kris Nuttycombe <kris@nutty.land>",
     "Sean Bowe <ewillbefull@gmail.com>",


### PR DESCRIPTION
The `bridgetree-v0.2.0` tag was created with respect to an invalid repository state, which did not actually contain the `bridgetree` sources after they were factored out from the `incrementalmerkletree` crate.