### PR TITLE
Remove the `Debug` bound from `Hashable`

### DIFF
--- a/bridgetree/src/lib.rs
+++ b/bridgetree/src/lib.rs
@@ -1057,7 +1057,7 @@ mod tests {
         assert!(!tree.append('i'.to_string()));
     }
 
-    fn check_garbage_collect<H: Hashable + Clone + Ord, const DEPTH: u8>(
+    fn check_garbage_collect<H: Hashable + Clone + Ord + Debug, const DEPTH: u8>(
         mut tree: BridgeTree<H, usize, DEPTH>,
     ) {
         // Add checkpoints until we're sure everything that can be gc'ed will be gc'ed

--- a/incrementalmerkletree/src/lib.rs
+++ b/incrementalmerkletree/src/lib.rs
@@ -516,12 +516,15 @@ impl<H: Hashable, const DEPTH: u8> MerklePath<H, DEPTH> {
 
 /// A trait describing the operations that make a type suitable for use as
 /// a leaf or node value in a merkle tree.
-pub trait Hashable: Sized + core::fmt::Debug {
+pub trait Hashable {
     fn empty_leaf() -> Self;
 
     fn combine(level: Level, a: &Self, b: &Self) -> Self;
 
-    fn empty_root(level: Level) -> Self {
+    fn empty_root(level: Level) -> Self
+    where
+        Self: Sized,
+    {
         Level::from(0)
             .iter_to(level)
             .fold(Self::empty_leaf(), |v, lvl| Self::combine(lvl, &v, &v))

--- a/incrementalmerkletree/src/testing.rs
+++ b/incrementalmerkletree/src/testing.rs
@@ -260,7 +260,7 @@ pub fn apply_operation<H, C, T: Tree<H, C>>(tree: &mut T, op: Operation<H, C>) {
     }
 }
 
-pub fn check_operations<H: Hashable + Ord + Clone, C: Clone, T: Tree<H, C>>(
+pub fn check_operations<H: Hashable + Ord + Clone + Debug, C: Clone, T: Tree<H, C>>(
     mut tree: T,
     ops: &[Operation<H, C>],
 ) -> Result<(), TestCaseError> {


### PR DESCRIPTION
The `Debug` bound here is handy but not required for the operations on the trait. Similarly, the `Sized` bound is only required for the `empty_root` operation.