### PR TITLE
allowing level 0 nodes means that Addresses are used for non-internal…

### DIFF
--- a/incrementalmerkletree/src/lib.rs
+++ b/incrementalmerkletree/src/lib.rs
@@ -286,7 +286,7 @@ impl Sub<u8> for Level {
     }
 }
 
-/// The address of an internal node of the Merkle tree.
+/// The address of a node of the Merkle tree.
 /// When `level == 0`, the index has the same value as the
 /// position.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
… nodes