### PR TITLE
shardtree: Pass checkpoints alongside tree to `ShardTree::insert_tree`

### DIFF
--- a/shardtree/src/batch.rs
+++ b/shardtree/src/batch.rs
@@ -487,12 +487,13 @@ mod tests {
         let mut left = ShardTree::new(MemoryShardStore::empty(), max_checkpoints);
         if let Some(BatchInsertionResult {
             subtree,
+            checkpoints,
             mut remainder,
             ..
         }) = LocatedPrunableTree::from_iter(start..end, 0.into(), leaves.clone().into_iter())
         {
             assert_eq!(remainder.next(), None);
-            left.insert_tree(subtree).unwrap();
+            left.insert_tree(subtree, checkpoints).unwrap();
         }
 
         // Construct a tree using `ShardTree::batch_insert`.


### PR DESCRIPTION
There are no `ShardTree` APIs that allow for checkpointing at arbitrary positions, which makes sense as the relevant leaf may have been pruned. For this API to be a viable substitute for `ShardTree::batch_insert`, it therefore needs to support marking any checkpoints associated with the inserted tree.