### PR TITLE
shardtree: Ensure `test-dependencies` feature enables `incrementalmerkletree/test-dependencies`

### DIFF
--- a/shardtree/Cargo.toml
+++ b/shardtree/Cargo.toml
@@ -36,7 +36,7 @@ proptest = "1.0.0"
 legacy-api = ["incrementalmerkletree/legacy-api"]
 # The test-depenencies feature can be enabled to expose types and functions
 # that are useful for testing `shardtree` functionality.
-test-dependencies = ["proptest", "assert_matches"]
+test-dependencies = ["proptest", "assert_matches", "incrementalmerkletree/test-dependencies"]
 
 [target.'cfg(unix)'.dev-dependencies]
 tempfile = ">=3, <3.7.0" # 3.7 has MSRV 1.63


### PR DESCRIPTION
This is intended to fix an issue with the `docs.rs` build.