### PR TITLE
Add max_checkpoints getter on ShardTree

### DIFF
--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -103,6 +103,11 @@ impl<
         &mut self.store
     }
 
+    /// Returns the maximum number of checkpoints to retain before pruning.
+    pub fn max_checkpoints(&self) -> usize {
+        self.max_checkpoints
+    }
+
     /// Returns the root address of the tree.
     pub fn root_addr() -> Address {
         Address::from_parts(Level::from(DEPTH), 0)


### PR DESCRIPTION
I'm currently implementing (de)serialization on the ShardTree and need this to perfectly roundtrip it. Regardless, don't see why this getter shouldn't be exposed anyways.