### PR TITLE
Immutable For Each on ShardStore Checkpoints

### DIFF
--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to Rust's notion of
 
 ## Unreleased
 
+### Added
+- `shardtree::store::ShardStore::for_each_checkpoint`
+
 ## [0.4.0] - 2024-08-12
 
 This is a bugfix release that fixes a couple of subtle problems related to

--- a/shardtree/src/store.rs
+++ b/shardtree/src/store.rs
@@ -116,6 +116,12 @@ pub trait ShardStore {
     where
         F: FnMut(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>;
 
+    /// Calls the given callback for each checkpoint in `CheckpointId` order. This is
+    /// essentially the immutable version of `with_checkpoints`.
+    fn for_each_checkpoint<F>(&self, limit: usize, callback: F) -> Result<(), Self::Error>
+    where
+        F: Fn(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>;
+
     /// Update the checkpoint having the given identifier by mutating it with the provided
     /// function, and persist the updated checkpoint to the data store.
     ///
@@ -216,6 +222,13 @@ impl<S: ShardStore> ShardStore for &mut S {
         F: FnMut(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
     {
         S::with_checkpoints(self, limit, callback)
+    }
+
+    fn for_each_checkpoint<F>(&self, limit: usize, callback: F) -> Result<(), Self::Error>
+    where
+        F: Fn(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
+    {
+        S::for_each_checkpoint(self, limit, callback)
     }
 
     fn update_checkpoint_with<F>(

--- a/shardtree/src/store.rs
+++ b/shardtree/src/store.rs
@@ -120,7 +120,7 @@ pub trait ShardStore {
     /// essentially the immutable version of `with_checkpoints`.
     fn for_each_checkpoint<F>(&self, limit: usize, callback: F) -> Result<(), Self::Error>
     where
-        F: Fn(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>;
+        F: FnMut(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>;
 
     /// Update the checkpoint having the given identifier by mutating it with the provided
     /// function, and persist the updated checkpoint to the data store.
@@ -226,7 +226,7 @@ impl<S: ShardStore> ShardStore for &mut S {
 
     fn for_each_checkpoint<F>(&self, limit: usize, callback: F) -> Result<(), Self::Error>
     where
-        F: Fn(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
+        F: FnMut(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
     {
         S::for_each_checkpoint(self, limit, callback)
     }

--- a/shardtree/src/store/caching.rs
+++ b/shardtree/src/store/caching.rs
@@ -184,6 +184,12 @@ where
     {
         self.cache.with_checkpoints(limit, callback)
     }
+    fn for_each_checkpoint<F>(&self, limit: usize, callback: F) -> Result<(), Self::Error>
+    where
+        F: Fn(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
+    {
+        self.cache.for_each_checkpoint(limit, callback)
+    }
 
     fn update_checkpoint_with<F>(
         &mut self,

--- a/shardtree/src/store/caching.rs
+++ b/shardtree/src/store/caching.rs
@@ -186,7 +186,7 @@ where
     }
     fn for_each_checkpoint<F>(&self, limit: usize, callback: F) -> Result<(), Self::Error>
     where
-        F: Fn(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
+        F: FnMut(&Self::CheckpointId, &Checkpoint) -> Result<(), Self::Error>,
     {
         self.cache.for_each_checkpoint(limit, callback)
     }

--- a/shardtree/src/store/memory.rs
+++ b/shardtree/src/store/memory.rs
@@ -137,6 +137,17 @@ impl<H: Clone, C: Clone + Ord> ShardStore for MemoryShardStore<H, C> {
         Ok(())
     }
 
+    fn for_each_checkpoint<F>(&self, limit: usize, callback: F) -> Result<(), Self::Error>
+    where
+        F: Fn(&C, &Checkpoint) -> Result<(), Self::Error>,
+    {
+        for (cid, checkpoint) in self.checkpoints.iter().take(limit) {
+            callback(cid, checkpoint)?
+        }
+
+        Ok(())
+    }
+
     fn update_checkpoint_with<F>(
         &mut self,
         checkpoint_id: &C,

--- a/shardtree/src/store/memory.rs
+++ b/shardtree/src/store/memory.rs
@@ -137,9 +137,9 @@ impl<H: Clone, C: Clone + Ord> ShardStore for MemoryShardStore<H, C> {
         Ok(())
     }
 
-    fn for_each_checkpoint<F>(&self, limit: usize, callback: F) -> Result<(), Self::Error>
+    fn for_each_checkpoint<F>(&self, limit: usize, mut callback: F) -> Result<(), Self::Error>
     where
-        F: Fn(&C, &Checkpoint) -> Result<(), Self::Error>,
+        F: FnMut(&C, &Checkpoint) -> Result<(), Self::Error>,
     {
         for (cid, checkpoint) in self.checkpoints.iter().take(limit) {
             callback(cid, checkpoint)?


### PR DESCRIPTION
The only ways to iterate over Checkpoints in the ShardStore is
1. Use the `with_checkpoints` method. The problem with this is that it require a mut reference to the store which isn't always available (e.g. in serialization).
2. Get the `min_checkpoint_id` and the `max_checkpoint_id` and then casting that to some primitive type if `CheckpointId` is `From/To <numeric>` then calling `get_checkpoint` over the range of that (very not ergonomic!!!).

This PR introduces `for_each_checkpoint` which is literally the same as `with_checkpoints` but takes an immutable reference to the store. 


I actually wanted to rename `with_checkpoints` to `for_each_checkpoint_mut` and call this `for_each_checkpoint` OR call them `with_checkpoints` and `with_checkpoints_mut` but I didn't want to make a breaking API change!