### PR TITLE
Release `bridgetree` version 0.6.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,10 @@
 members = [
     "incrementalmerkletree",
     "incrementalmerkletree-testing",
-    "bridgetree",
     "shardtree",
+]
+exclude = [
+    "bridgetree",
 ]
 
 [workspace.package]

--- a/bridgetree/CHANGELOG.md
+++ b/bridgetree/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-09-25
+
 ### Changed
 - MSRV is now 1.64
+- Migrated to `incrementalmerkletree 0.7`.
 
 ## [0.5.0] - 2024-08-12
 

--- a/bridgetree/Cargo.lock
+++ b/bridgetree/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,10 +30,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+name = "bridgetree"
+version = "0.6.0"
+dependencies = [
+ "incrementalmerkletree",
+ "incrementalmerkletree-testing",
+ "proptest",
+]
 
 [[package]]
 name = "byteorder"
@@ -104,17 +101,20 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 [[package]]
 name = "incrementalmerkletree"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45063fbc4b0a37837f6bfe0445f269d13d730ad0aa3b5a7f74aa7bf27a0f4df"
 dependencies = [
  "either",
  "proptest",
  "rand",
- "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "incrementalmerkletree-testing"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6959842a2ad15e423a7c39b77555039efdccf50a1a43cce43827fc2f881c27d2"
 dependencies = [
  "incrementalmerkletree",
  "proptest",
@@ -175,31 +175,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
-dependencies = [
- "unicode-ident",
-]
 
 [[package]]
 name = "proptest"
@@ -208,7 +187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
+ "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -226,15 +205,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quote"
-version = "1.0.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "rand"
@@ -281,7 +251,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -296,7 +266,7 @@ version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
@@ -317,31 +287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shardtree"
-version = "0.4.0"
-dependencies = [
- "assert_matches",
- "bitflags 2.4.1",
- "either",
- "incrementalmerkletree",
- "incrementalmerkletree-testing",
- "proptest",
- "tempfile",
- "tracing",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,47 +301,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "wait-timeout"

--- a/bridgetree/Cargo.toml
+++ b/bridgetree/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "bridgetree"
 description = "A space-efficient Merkle tree designed for linear appends with witnessing of marked leaves, checkpointing & state restoration."
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Kris Nuttycombe <kris@nutty.land>",
     "Sean Bowe <ewillbefull@gmail.com>",
 ]
-edition.workspace = true
-license.workspace = true
-homepage.workspace = true
-repository.workspace = true
-categories.workspace = true
-rust-version.workspace = true
+edition = "2021"
+rust-version = "1.64"
+repository = "https://github.com/zcash/incrementalmerkletree"
+homepage = "https://github.com/zcash/incrementalmerkletree"
+license = "MIT OR Apache-2.0"
+categories = ["algorithms", "data-structures"]
 
 [dependencies]
-incrementalmerkletree.workspace = true
-proptest = { workspace = true, optional = true }
+incrementalmerkletree = "0.7"
+proptest = { version = "1", optional = true }
 
 [dev-dependencies]
-incrementalmerkletree = { workspace = true, features = ["test-dependencies"] }
-incrementalmerkletree-testing.workspace = true
-proptest.workspace = true
+incrementalmerkletree = { version = "0.7", features = ["test-dependencies"] }
+incrementalmerkletree-testing = "0.1"
+proptest = "1"
 
 [features]
 test-dependencies = ["proptest"]


### PR DESCRIPTION
This change removes `bridgetree` from the workspace, so that it will no longer be maintained in lockstep with changes to the `incrementalmerkletree` crate. `bridgetree` will only receive bug-fix changes in the future.