### PR TITLE
Add methods to obtain the current frontier for `ShardTree` and `LocatedPrunableTree` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 exclude = [
     "bridgetree",
 ]
+resolver = "2"
 
 [workspace.package]
 edition = "2021"

--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to Rust's notion of
 ## Unreleased
 
 ### Added
-- `shardtree::prunable::LocatedPrunableTree::frontier`
+- `shardtree::prunable::{LocatedPrunableTree::frontier, FrontierError}`
 - `shardtree::ShardTree::frontier`
 
 ## [0.6.1] - 2025-01-30

--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to Rust's notion of
 
 ## Unreleased
 
+### Added
+- `shardtree::prunable::LocatedPrunableTree::frontier`
+
 ## [0.6.1] - 2025-01-30
 
 ### Changed

--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to Rust's notion of
 
 ### Added
 - `shardtree::prunable::LocatedPrunableTree::frontier`
+- `shardtree::ShardTree::frontier`
 
 ## [0.6.1] - 2025-01-30
 

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -160,6 +160,42 @@ impl<
         Ok(result)
     }
 
+    /// Returns the frontier of the tree.
+    ///
+    /// The frontier consists of the rightmost leaf and the ommers (sibling hashes)
+    /// needed to compute the root. This method assembles ommers from within the
+    /// last shard (below `SHARD_HEIGHT`) and from sibling subtree roots above the
+    /// shard level.
+    ///
+    /// Returns [`Frontier::empty`] if the tree has no shards or if the frontier
+    /// cannot be determined from the available data.
+    pub fn frontier(&self) -> Result<Frontier<H, DEPTH>, ShardTreeError<S::Error>> {
+        let last_shard = self.store.last_shard().map_err(ShardTreeError::Storage)?;
+        let last_shard = match last_shard {
+            Some(s) => s,
+            None => return Ok(Frontier::empty()),
+        };
+
+        let (position, leaf, mut ommers) = match last_shard.frontier_ommers() {
+            Some(parts) => parts,
+            None => return Ok(Frontier::empty()),
+        };
+
+        // Walk from the shard root address up to the tree root, collecting ommers
+        // from sibling subtrees above the shard level.
+        let mut cur_addr = last_shard.root_addr;
+        while cur_addr.level() < Level::from(DEPTH) {
+            if cur_addr.is_right_child() {
+                let sibling_hash = self.root(cur_addr.sibling(), position + 1)?;
+                ommers.push(sibling_hash);
+            }
+            cur_addr = cur_addr.parent();
+        }
+
+        Frontier::from_parts(position, leaf, ommers)
+            .map_err(|_| ShardTreeError::Query(QueryError::TreeIncomplete(vec![Self::root_addr()])))
+    }
+
     /// Inserts a new root into the tree at the given address.
     ///
     /// The level associated with the given address may not exceed `DEPTH`.
@@ -1471,6 +1507,124 @@ mod tests {
     fn rewind_remove_mark() {
         check_rewind_remove_mark(new_tree);
     }
+
+    #[test]
+    fn frontier_empty_tree() {
+        let tree: ShardTree<MemoryShardStore<String, u32>, 4, 3> =
+            ShardTree::new(MemoryShardStore::empty(), 100);
+        assert_eq!(tree.frontier().unwrap(), Frontier::empty());
+    }
+
+    #[test]
+    fn frontier_single_leaf() {
+        let mut tree: ShardTree<MemoryShardStore<String, u32>, 4, 3> =
+            ShardTree::new(MemoryShardStore::empty(), 100);
+        tree.append("a".to_string(), Retention::Ephemeral).unwrap();
+
+        let frontier = tree.frontier().unwrap();
+        assert_eq!(
+            frontier,
+            Frontier::from_parts(Position::from(0), "a".to_string(), vec![]).unwrap()
+        );
+    }
+
+    #[test]
+    fn frontier_within_single_shard() {
+        // Insert a frontier at position 5 within the first shard (SHARD_HEIGHT=3).
+        // Position 5 = binary 101: ommers at level 0 ("e") and level 2 ("abcd").
+        let original = NonEmptyFrontier::from_parts(
+            Position::from(5),
+            "f".to_string(),
+            vec!["e".to_string(), "abcd".to_string()],
+        )
+        .unwrap();
+
+        let mut tree: ShardTree<MemoryShardStore<String, u32>, 4, 3> =
+            ShardTree::new(MemoryShardStore::empty(), 100);
+        tree.insert_frontier_nodes(original.clone(), Retention::Ephemeral)
+            .unwrap();
+
+        let frontier = tree.frontier().unwrap();
+        assert_eq!(frontier.value(), Some(&original));
+    }
+
+    #[test]
+    fn frontier_multi_shard_roundtrip() {
+        // Insert a frontier at position 9, which is in the second shard (SHARD_HEIGHT=3).
+        // Position 9 = binary 1001: ommers at level 0 ("i") and level 3 ("abcdefgh").
+        // Level 0 ommer "i" is within the shard; level 3 ommer "abcdefgh" is the
+        // sibling shard's root above the shard level.
+        let original = NonEmptyFrontier::from_parts(
+            Position::from(9),
+            "j".to_string(),
+            vec!["i".to_string(), "abcdefgh".to_string()],
+        )
+        .unwrap();
+
+        let mut tree: ShardTree<MemoryShardStore<String, u32>, 4, 3> =
+            ShardTree::new(MemoryShardStore::empty(), 100);
+        tree.insert_frontier_nodes(original.clone(), Retention::Ephemeral)
+            .unwrap();
+
+        let frontier = tree.frontier().unwrap();
+        assert_eq!(frontier.value(), Some(&original));
+    }
+
+    #[test]
+    fn frontier_from_appended_leaves() {
+        // Append leaves with the last one marked, so it isn't pruned away.
+        let mut tree: ShardTree<MemoryShardStore<String, u32>, 4, 3> =
+            ShardTree::new(MemoryShardStore::empty(), 100);
+        for c in 'a'..='i' {
+            tree.append(c.to_string(), Retention::Ephemeral).unwrap();
+        }
+        tree.append("j".to_string(), Retention::Marked).unwrap();
+
+        let frontier = tree.frontier().unwrap();
+        // Position 9 = binary 1001: ommers at level 0 ("i") and level 3 ("abcdefgh")
+        let expected = NonEmptyFrontier::from_parts(
+            Position::from(9),
+            "j".to_string(),
+            vec!["i".to_string(), "abcdefgh".to_string()],
+        )
+        .unwrap();
+        assert_eq!(frontier.value(), Some(&expected));
+    }
+
+    #[test]
+    fn frontier_with_append() {
+        // Insert a frontier at position 9, which is in the second shard (SHARD_HEIGHT=3).
+        // Position 9 = binary 1001: ommers at level 0 ("i") and level 3 ("abcdefgh").
+        // Level 0 ommer "i" is within the shard; level 3 ommer "abcdefgh" is the
+        // sibling shard's root above the shard level.
+        let original = NonEmptyFrontier::from_parts(
+            Position::from(9),
+            "j".to_string(),
+            vec!["i".to_string(), "abcdefgh".to_string()],
+        )
+        .unwrap();
+
+        let mut tree: ShardTree<MemoryShardStore<String, u32>, 4, 3> =
+            ShardTree::new(MemoryShardStore::empty(), 100);
+        tree.insert_frontier_nodes(original.clone(), Retention::Ephemeral)
+            .unwrap();
+
+        // Now, append leaves to the inserted frontier state.
+        for c in 'k'..='n' {
+            tree.append(c.to_string(), Retention::Ephemeral).unwrap();
+        }
+        tree.append("o".to_string(), Retention::Marked).unwrap();
+
+        let frontier = tree.frontier().unwrap();
+        let expected = NonEmptyFrontier::from_parts(
+            Position::from(14),
+            "o".to_string(),
+            vec!["mn".to_string(), "ijkl".to_string(), "abcdefgh".to_string()],
+        )
+        .unwrap();
+        assert_eq!(frontier.value(), Some(&expected));
+    }
+
 
     #[test]
     fn checkpoint_pruning_repeated() {

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -1619,7 +1619,7 @@ mod tests {
 
         let mut tree: ShardTree<MemoryShardStore<String, u32>, 4, 3> =
             ShardTree::new(MemoryShardStore::empty(), 100);
-        tree.insert_frontier_nodes(original.clone(), Retention::Ephemeral)
+        tree.insert_frontier_nodes(original, Retention::Ephemeral)
             .unwrap();
 
         // Now, append leaves to the inserted frontier state.

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -176,10 +176,22 @@ impl<
             None => return Ok(Frontier::empty()),
         };
 
-        let (position, leaf, mut ommers) = match last_shard.frontier_ommers() {
-            Some(parts) => parts,
-            None => return Ok(Frontier::empty()),
-        };
+        let (position, leaf, mut ommers) =
+            match last_shard.frontier_ommers().map_err(|e| match e {
+                prunable::FrontierError::TreeIncomplete { address } => {
+                    ShardTreeError::Query(QueryError::TreeIncomplete(vec![address]))
+                }
+                _ => {
+                    // FIXME: We need a breaking release to add a more correct error type
+                    // for this case; at that time, we should also make `ShardTreeError`
+                    // non-exhaustive.
+                    let shard_addr = last_shard.root_addr();
+                    ShardTreeError::Query(QueryError::TreeIncomplete(vec![shard_addr]))
+                }
+            })? {
+                Some(parts) => parts,
+                None => return Ok(Frontier::empty()),
+            };
 
         // Walk from the shard root address up to the tree root, collecting ommers
         // from sibling subtrees above the shard level.
@@ -192,6 +204,7 @@ impl<
             cur_addr = cur_addr.parent();
         }
 
+        // FIXME: this should also have a better error variant.
         Frontier::from_parts(position, leaf, ommers)
             .map_err(|_| ShardTreeError::Query(QueryError::TreeIncomplete(vec![Self::root_addr()])))
     }
@@ -1624,7 +1637,6 @@ mod tests {
         .unwrap();
         assert_eq!(frontier.value(), Some(&expected));
     }
-
 
     #[test]
     fn checkpoint_pruning_repeated() {

--- a/shardtree/src/prunable.rs
+++ b/shardtree/src/prunable.rs
@@ -1028,9 +1028,13 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
         result
     }
 
-    /// Returns the Merkle frontier of the tree, if the tree is nonempty and has no `Nil` leaves
-    /// prior to the leaf at the greatest position.
-    pub fn frontier(&self) -> Option<NonEmptyFrontier<H>> {
+    /// Returns the position, leaf hash, and ommers for the frontier of this tree,
+    /// or `None` if the frontier cannot be determined.
+    ///
+    /// The returned ommers cover only the levels within this tree (from level 0 up to
+    /// but not including this tree's root level). This is a building block for
+    /// [`ShardTree::frontier`] which extends the ommers to the full tree depth.
+    pub(crate) fn frontier_ommers(&self) -> Option<(Position, H, Vec<H>)> {
         /// Traverses the rightmost path of the tree, collecting the frontier leaf and ommers.
         /// Returns `(position, leaf_hash, ommers)` with ommers ordered from lowest to highest
         /// level, or `None` if the frontier cannot be extracted.
@@ -1073,7 +1077,13 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
             }
         }
 
-        let (position, leaf, ommers) = go(self.root_addr, &self.root)?;
+        go(self.root_addr, &self.root)
+    }
+
+    /// Returns the Merkle frontier of the tree, if the tree is nonempty and has no `Nil` leaves
+    /// prior to the leaf at the greatest position.
+    pub fn frontier(&self) -> Option<NonEmptyFrontier<H>> {
+        let (position, leaf, ommers) = self.frontier_ommers()?;
         NonEmptyFrontier::from_parts(position, leaf, ommers).ok()
     }
 }

--- a/shardtree/src/prunable.rs
+++ b/shardtree/src/prunable.rs
@@ -1027,6 +1027,55 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
         go(&self.root, self.root_addr, &mut result);
         result
     }
+
+    /// Returns the Merkle frontier of the tree, if the tree is nonempty and has no `Nil` leaves
+    /// prior to the leaf at the greatest position.
+    pub fn frontier(&self) -> Option<NonEmptyFrontier<H>> {
+        /// Traverses the rightmost path of the tree, collecting the frontier leaf and ommers.
+        /// Returns `(position, leaf_hash, ommers)` with ommers ordered from lowest to highest
+        /// level, or `None` if the frontier cannot be extracted.
+        ///
+        /// Pre-condition: `addr` must be the address of `root`.
+        fn go<H: Hashable + Clone + PartialEq>(
+            addr: Address,
+            root: &PrunableTree<H>,
+        ) -> Option<(Position, H, Vec<H>)> {
+            match &root.0 {
+                Node::Nil => None,
+                Node::Leaf { value: (h, _) } => {
+                    if addr.level() == Level::ZERO {
+                        Some((Position::from(addr.index()), h.clone(), vec![]))
+                    } else {
+                        // A leaf above level 0 is a pruned subtree; we cannot extract
+                        // the frontier leaf or internal ommers.
+                        None
+                    }
+                }
+                Node::Parent { left, right, .. } => {
+                    let (l_addr, r_addr) = addr
+                        .children()
+                        .expect("A parent node cannot appear at level 0");
+
+                    if right.0.is_nil() {
+                        // Right subtree is empty; the frontier is in the left subtree
+                        // and no ommer is needed at this level.
+                        go(l_addr, left)
+                    } else {
+                        // Right subtree is populated; the frontier is within it.
+                        // The left subtree's root hash becomes an ommer.
+                        let (pos, leaf, mut ommers) = go(r_addr, right)?;
+                        let left_hash =
+                            left.root_hash(l_addr, r_addr.position_range_start()).ok()?;
+                        ommers.push(left_hash);
+                        Some((pos, leaf, ommers))
+                    }
+                }
+            }
+        }
+
+        let (position, leaf, ommers) = go(self.root_addr, &self.root)?;
+        NonEmptyFrontier::from_parts(position, leaf, ommers).ok()
+    }
 }
 
 // We need an applicative functor for Result for this function so that we can correctly
@@ -1051,7 +1100,7 @@ fn accumulate_result_with<A, B, C>(
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
 
-    use incrementalmerkletree::{Address, Level, Position};
+    use incrementalmerkletree::{frontier::NonEmptyFrontier, Address, Level, Position};
     use proptest::proptest;
 
     use super::{LocatedPrunableTree, PrunableTree, RetentionFlags};
@@ -1277,6 +1326,230 @@ mod tests {
                 3
             )]))
         );
+    }
+
+    #[test]
+    fn frontier_empty_tree() {
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(2.into(), 0),
+            root: nil(),
+        };
+        assert_eq!(t.frontier(), None);
+    }
+
+    #[test]
+    fn frontier_single_leaf() {
+        // A single leaf at position 0
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(0.into(), 0),
+            root: leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+        };
+        assert_eq!(
+            t.frontier(),
+            Some(NonEmptyFrontier::from_parts(Position::from(0), "a".to_string(), vec![]).unwrap())
+        );
+    }
+
+    #[test]
+    fn frontier_two_leaves() {
+        // Positions 0 and 1 populated
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(1.into(), 0),
+            root: parent(
+                leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+            ),
+        };
+        // Position 1 = binary 1: ommer at level 0 = "a"
+        assert_eq!(
+            t.frontier(),
+            Some(
+                NonEmptyFrontier::from_parts(
+                    Position::from(1),
+                    "b".to_string(),
+                    vec!["a".to_string()]
+                )
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn frontier_left_only() {
+        // Only left child populated (position 0), right is Nil
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(1.into(), 0),
+            root: parent(leaf(("a".to_string(), RetentionFlags::EPHEMERAL)), nil()),
+        };
+        // Position 0, no ommers
+        assert_eq!(
+            t.frontier(),
+            Some(NonEmptyFrontier::from_parts(Position::from(0), "a".to_string(), vec![]).unwrap())
+        );
+    }
+
+    #[test]
+    fn frontier_deeper_tree() {
+        // Positions 0-5 populated at level 3
+        //           root
+        //          /    \
+        //       (l2,0)  (l2,1)
+        //       / \      / \
+        //     ab   cd   ef  Nil
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(3.into(), 0),
+            root: parent(
+                parent(
+                    parent(
+                        leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                        leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                    ),
+                    parent(
+                        leaf(("c".to_string(), RetentionFlags::EPHEMERAL)),
+                        leaf(("d".to_string(), RetentionFlags::EPHEMERAL)),
+                    ),
+                ),
+                parent(
+                    parent(
+                        leaf(("e".to_string(), RetentionFlags::EPHEMERAL)),
+                        leaf(("f".to_string(), RetentionFlags::EPHEMERAL)),
+                    ),
+                    nil(),
+                ),
+            ),
+        };
+
+        // Position 5 = binary 101: ommers at levels 0 and 2
+        // Level 0 ommer: "e" (sibling of "f")
+        // Level 2 ommer: hash of left subtree = "abcd"
+        assert_eq!(
+            t.frontier(),
+            Some(
+                NonEmptyFrontier::from_parts(
+                    Position::from(5),
+                    "f".to_string(),
+                    vec!["e".to_string(), "abcd".to_string()]
+                )
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn frontier_with_pruned_left_sibling() {
+        // Left subtree is a pruned leaf (at level > 0), right subtree has detail
+        //        root (level 3)
+        //       /        \
+        //   "abcd"     (l2,1)
+        //  (pruned)     / \
+        //             ef   Nil
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(3.into(), 0),
+            root: parent(
+                leaf(("abcd".to_string(), RetentionFlags::EPHEMERAL)),
+                parent(
+                    parent(
+                        leaf(("e".to_string(), RetentionFlags::EPHEMERAL)),
+                        leaf(("f".to_string(), RetentionFlags::EPHEMERAL)),
+                    ),
+                    nil(),
+                ),
+            ),
+        };
+
+        // The pruned left sibling's hash "abcd" should be used as the level-2 ommer
+        assert_eq!(
+            t.frontier(),
+            Some(
+                NonEmptyFrontier::from_parts(
+                    Position::from(5),
+                    "f".to_string(),
+                    vec!["e".to_string(), "abcd".to_string()]
+                )
+                .unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn frontier_with_nil_left_sibling() {
+        // Left subtree is Nil (incomplete), right has the frontier
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(2.into(), 0),
+            root: parent(
+                nil(),
+                parent(
+                    leaf(("c".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("d".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+            ),
+        };
+
+        // Should return None because the left sibling is Nil (incomplete)
+        assert_eq!(t.frontier(), None);
+    }
+
+    #[test]
+    fn frontier_pruned_rightmost_subtree() {
+        // Rightmost path hits a pruned leaf at level > 0
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(2.into(), 0),
+            root: parent(
+                parent(
+                    leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+                leaf(("cd".to_string(), RetentionFlags::EPHEMERAL)),
+            ),
+        };
+
+        // Right child is a leaf at level 1 (pruned subtree); can't extract frontier
+        assert_eq!(t.frontier(), None);
+    }
+
+    #[test]
+    fn frontier_nonzero_index_shard() {
+        // A shard at index 1 (positions 4-7): the absolute position has bits
+        // above the shard level, so NonEmptyFrontier::from_parts will fail.
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(2.into(), 1),
+            root: parent(
+                parent(
+                    leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+                nil(),
+            ),
+        };
+
+        // Position 5 (binary 101) needs 2 ommers, but we only have 1 within the shard
+        // (level 0 ommer "a"). The bit at level 2 is set in position 5, requiring an
+        // ommer we don't have. from_parts rejects this.
+        assert_eq!(t.frontier(), None);
+    }
+
+    #[test]
+    fn frontier_roundtrip_via_insert() {
+        use incrementalmerkletree::Retention;
+
+        // Build a frontier, insert it into an empty tree, then extract it back
+        let frontier = NonEmptyFrontier::from_parts(
+            Position::from(5),
+            "f".to_string(),
+            vec!["e".to_string(), "abcd".to_string()],
+        )
+        .unwrap();
+
+        let empty_tree: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(3.into(), 0),
+            root: nil(),
+        };
+
+        let (filled_tree, _) = empty_tree
+            .insert_frontier_nodes(frontier.clone(), &Retention::<()>::Ephemeral)
+            .unwrap();
+
+        assert_eq!(filled_tree.frontier(), Some(frontier));
     }
 
     proptest! {

--- a/shardtree/src/prunable.rs
+++ b/shardtree/src/prunable.rs
@@ -388,6 +388,39 @@ pub struct IncompleteAt {
     pub required_for_witness: bool,
 }
 
+/// Validation errors that can occur during reconstruction of a Merkle frontier from
+/// the state of a [`LocatedPrunableTree`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FrontierError {
+    /// An error representing that the number of ommers provided in frontier construction does not
+    /// the expected length of the ommers list given the position.
+    PositionMismatch { expected_ommers: u8 },
+    /// An error representing that the position and/or list of ommers provided to frontier
+    /// construction would result in a frontier that exceeds the maximum statically allowed depth
+    /// of the tree. `depth` is the minimum tree depth that would be required in order for that
+    /// tree to contain the position in question.
+    MaxDepthExceeded { depth: u8 },
+    /// The tree from which the frontier was being extracted is incomplete, and consequently no
+    /// frontier can be computed.
+    TreeIncomplete { address: Address },
+    /// The tree from which the frontier was being extracted is corrupt; an invalid node was found
+    /// at the given address.
+    CorruptedData { address: Address },
+}
+
+impl From<incrementalmerkletree::frontier::FrontierError> for FrontierError {
+    fn from(value: incrementalmerkletree::frontier::FrontierError) -> Self {
+        use incrementalmerkletree::frontier::FrontierError::*;
+        match value {
+            PositionMismatch { expected_ommers } => {
+                FrontierError::PositionMismatch { expected_ommers }
+            }
+            MaxDepthExceeded { depth } => FrontierError::MaxDepthExceeded { depth },
+        }
+    }
+}
+
 impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
     /// Returns the maximum position at which a non-`Nil` leaf has been observed in the tree.
     ///
@@ -1028,37 +1061,37 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
         result
     }
 
-    /// Returns the position, leaf hash, and ommers for the frontier of this tree,
-    /// or `None` if the frontier cannot be determined.
+    /// Returns the position, leaf hash, and ommers for the frontier of this tree, `Ok(None)` if
+    /// the tree is empty, or `Err(())` if the frontier cannot be computed due to missing data.
     ///
     /// The returned ommers cover only the levels within this tree (from level 0 up to
     /// but not including this tree's root level). This is a building block for
     /// [`ShardTree::frontier`] which extends the ommers to the full tree depth.
-    pub(crate) fn frontier_ommers(&self) -> Option<(Position, H, Vec<H>)> {
+    pub(crate) fn frontier_ommers(&self) -> Result<Option<(Position, H, Vec<H>)>, FrontierError> {
         /// Traverses the rightmost path of the tree, collecting the frontier leaf and ommers.
         /// Returns `(position, leaf_hash, ommers)` with ommers ordered from lowest to highest
         /// level, or `None` if the frontier cannot be extracted.
         ///
         /// Pre-condition: `addr` must be the address of `root`.
         fn go<H: Hashable + Clone + PartialEq>(
-            addr: Address,
+            address: Address,
             root: &PrunableTree<H>,
-        ) -> Option<(Position, H, Vec<H>)> {
+        ) -> Result<Option<(Position, H, Vec<H>)>, FrontierError> {
             match &root.0 {
-                Node::Nil => None,
+                Node::Nil => Err(FrontierError::TreeIncomplete { address }),
                 Node::Leaf { value: (h, _) } => {
-                    if addr.level() == Level::ZERO {
-                        Some((Position::from(addr.index()), h.clone(), vec![]))
+                    if address.level() == Level::ZERO {
+                        Ok(Some((Position::from(address.index()), h.clone(), vec![])))
                     } else {
                         // A leaf above level 0 is a pruned subtree; we cannot extract
                         // the frontier leaf or internal ommers.
-                        None
+                        Err(FrontierError::TreeIncomplete { address })
                     }
                 }
                 Node::Parent { left, right, .. } => {
-                    let (l_addr, r_addr) = addr
+                    let (l_addr, r_addr) = address
                         .children()
-                        .expect("A parent node cannot appear at level 0");
+                        .ok_or(FrontierError::CorruptedData { address })?;
 
                     if right.0.is_nil() {
                         // Right subtree is empty; the frontier is in the left subtree
@@ -1067,24 +1100,36 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
                     } else {
                         // Right subtree is populated; the frontier is within it.
                         // The left subtree's root hash becomes an ommer.
-                        let (pos, leaf, mut ommers) = go(r_addr, right)?;
-                        let left_hash =
-                            left.root_hash(l_addr, r_addr.position_range_start()).ok()?;
-                        ommers.push(left_hash);
-                        Some((pos, leaf, ommers))
+                        go(r_addr, right)?
+                            .map(|(pos, leaf, mut ommers)| {
+                                let left_hash = left
+                                    .root_hash(l_addr, r_addr.position_range_start())
+                                    .map_err(|_| FrontierError::TreeIncomplete {
+                                        address: l_addr,
+                                    })?;
+                                ommers.push(left_hash);
+                                Ok((pos, leaf, ommers))
+                            })
+                            .transpose()
                     }
                 }
             }
         }
 
-        go(self.root_addr, &self.root)
+        if self.root.is_nil() {
+            Ok(None)
+        } else {
+            go(self.root_addr, &self.root)
+        }
     }
 
     /// Returns the Merkle frontier of the tree, if the tree is nonempty and has no `Nil` leaves
     /// prior to the leaf at the greatest position.
-    pub fn frontier(&self) -> Option<NonEmptyFrontier<H>> {
-        let (position, leaf, ommers) = self.frontier_ommers()?;
-        NonEmptyFrontier::from_parts(position, leaf, ommers).ok()
+    pub fn frontier(&self) -> Result<Option<NonEmptyFrontier<H>>, FrontierError> {
+        self.frontier_ommers()?
+            .map(|(position, leaf, ommers)| NonEmptyFrontier::from_parts(position, leaf, ommers))
+            .transpose()
+            .map_err(FrontierError::from)
     }
 }
 
@@ -1108,6 +1153,7 @@ fn accumulate_result_with<A, B, C>(
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use std::collections::{BTreeMap, BTreeSet};
 
     use incrementalmerkletree::{frontier::NonEmptyFrontier, Address, Level, Position};
@@ -1116,7 +1162,7 @@ mod tests {
     use super::{LocatedPrunableTree, PrunableTree, RetentionFlags};
     use crate::{
         error::{InsertionError, QueryError},
-        prunable::MergeError,
+        prunable::{FrontierError, MergeError},
         testing::{arb_char_str, arb_prunable_tree},
         tree::{
             tests::{leaf, nil, parent},
@@ -1344,7 +1390,7 @@ mod tests {
             root_addr: Address::from_parts(2.into(), 0),
             root: nil(),
         };
-        assert_eq!(t.frontier(), None);
+        assert_eq!(t.frontier(), Ok(None));
     }
 
     #[test]
@@ -1356,7 +1402,9 @@ mod tests {
         };
         assert_eq!(
             t.frontier(),
-            Some(NonEmptyFrontier::from_parts(Position::from(0), "a".to_string(), vec![]).unwrap())
+            Ok(Some(
+                NonEmptyFrontier::from_parts(Position::from(0), "a".to_string(), vec![]).unwrap()
+            ))
         );
     }
 
@@ -1373,14 +1421,14 @@ mod tests {
         // Position 1 = binary 1: ommer at level 0 = "a"
         assert_eq!(
             t.frontier(),
-            Some(
+            Ok(Some(
                 NonEmptyFrontier::from_parts(
                     Position::from(1),
                     "b".to_string(),
                     vec!["a".to_string()]
                 )
                 .unwrap()
-            )
+            ))
         );
     }
 
@@ -1394,7 +1442,9 @@ mod tests {
         // Position 0, no ommers
         assert_eq!(
             t.frontier(),
-            Some(NonEmptyFrontier::from_parts(Position::from(0), "a".to_string(), vec![]).unwrap())
+            Ok(Some(
+                NonEmptyFrontier::from_parts(Position::from(0), "a".to_string(), vec![]).unwrap()
+            ))
         );
     }
 
@@ -1434,14 +1484,14 @@ mod tests {
         // Level 2 ommer: hash of left subtree = "abcd"
         assert_eq!(
             t.frontier(),
-            Some(
+            Ok(Some(
                 NonEmptyFrontier::from_parts(
                     Position::from(5),
                     "f".to_string(),
                     vec!["e".to_string(), "abcd".to_string()]
                 )
                 .unwrap()
-            )
+            ))
         );
     }
 
@@ -1470,14 +1520,14 @@ mod tests {
         // The pruned left sibling's hash "abcd" should be used as the level-2 ommer
         assert_eq!(
             t.frontier(),
-            Some(
+            Ok(Some(
                 NonEmptyFrontier::from_parts(
                     Position::from(5),
                     "f".to_string(),
                     vec!["e".to_string(), "abcd".to_string()]
                 )
                 .unwrap()
-            )
+            ))
         );
     }
 
@@ -1496,7 +1546,7 @@ mod tests {
         };
 
         // Should return None because the left sibling is Nil (incomplete)
-        assert_eq!(t.frontier(), None);
+        assert_matches!(t.frontier(), Err(FrontierError::TreeIncomplete { .. }));
     }
 
     #[test]
@@ -1514,7 +1564,7 @@ mod tests {
         };
 
         // Right child is a leaf at level 1 (pruned subtree); can't extract frontier
-        assert_eq!(t.frontier(), None);
+        assert_matches!(t.frontier(), Err(FrontierError::TreeIncomplete { .. }));
     }
 
     #[test]
@@ -1535,7 +1585,7 @@ mod tests {
         // Position 5 (binary 101) needs 2 ommers, but we only have 1 within the shard
         // (level 0 ommer "a"). The bit at level 2 is set in position 5, requiring an
         // ommer we don't have. from_parts rejects this.
-        assert_eq!(t.frontier(), None);
+        assert_matches!(t.frontier(), Err(FrontierError::PositionMismatch { .. }));
     }
 
     #[test]
@@ -1559,7 +1609,7 @@ mod tests {
             .insert_frontier_nodes(frontier.clone(), &Retention::<()>::Ephemeral)
             .unwrap();
 
-        assert_eq!(filled_tree.frontier(), Some(frontier));
+        assert_eq!(filled_tree.frontier(), Ok(Some(frontier)));
     }
 
     proptest! {


### PR DESCRIPTION
Blocks zcash/librustzcash#2121