### PR TITLE
bridgetree: Memoize the root of the current frontier; release bridgetree 0.7.1

### DIFF
--- a/bridgetree/CHANGELOG.md
+++ b/bridgetree/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- `BridgeTree::root(0)` (the root of the current frontier) is now memoized. The
+  cached value is cleared by `append` and `rewind`, the only operations that
+  change the frontier; `checkpoint`, `mark`, `remove_mark`, and
+  `garbage_collect` preserve it. Repeated root queries between mutations are now
+  `O(1)` rather than re-folding the frontier against empty subtree roots up to
+  the full depth of the tree. As a consequence `BridgeTree` no longer implements
+  `Sync` (it now holds an interior-mutable cache); it remains `Send`. Equality
+  and the serialized form are unaffected, as the cache is excluded from both.
+
 ## [0.7.0] - 2025-06-04
 
 ### Changed

--- a/bridgetree/CHANGELOG.md
+++ b/bridgetree/CHANGELOG.md
@@ -7,15 +7,18 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
-### Changed
+### Optimization
 - `BridgeTree::root(0)` (the root of the current frontier) is now memoized. The
   cached value is cleared by `append` and `rewind`, the only operations that
   change the frontier; `checkpoint`, `mark`, `remove_mark`, and
   `garbage_collect` preserve it. Repeated root queries between mutations are now
   `O(1)` rather than re-folding the frontier against empty subtree roots up to
-  the full depth of the tree. As a consequence `BridgeTree` no longer implements
-  `Sync` (it now holds an interior-mutable cache); it remains `Send`. Equality
-  and the serialized form are unaffected, as the cache is excluded from both.
+  the full depth of the tree. The cache uses `std::sync::OnceLock`, so `BridgeTree`
+  remains both `Send` and `Sync`. Equality and the serialized form are unaffected,
+  as the cache is excluded from both.
+
+### Changed
+- MSRV is now 1.70 (for `std::sync::OnceLock`).
 
 ## [0.7.0] - 2025-06-04
 

--- a/bridgetree/CHANGELOG.md
+++ b/bridgetree/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.1] - 2026-06-07
 
 ### Optimization
 - `BridgeTree::root(0)` (the root of the current frontier) is now memoized. The

--- a/bridgetree/Cargo.lock
+++ b/bridgetree/Cargo.lock
@@ -31,7 +31,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bridgetree"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "incrementalmerkletree",
  "incrementalmerkletree-testing",

--- a/bridgetree/Cargo.toml
+++ b/bridgetree/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Sean Bowe <ewillbefull@gmail.com>",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.70"
 repository = "https://github.com/zcash/incrementalmerkletree"
 homepage = "https://github.com/zcash/incrementalmerkletree"
 license = "MIT OR Apache-2.0"

--- a/bridgetree/Cargo.toml
+++ b/bridgetree/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bridgetree"
 description = "A space-efficient Merkle tree designed for linear appends with witnessing of marked leaves, checkpointing & state restoration."
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Kris Nuttycombe <kris@nutty.land>",
     "Sean Bowe <ewillbefull@gmail.com>",

--- a/bridgetree/src/lib.rs
+++ b/bridgetree/src/lib.rs
@@ -731,7 +731,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                 if self
                     .prior_bridges
                     .last()
-                    .map_or(false, |prior_b| prior_b.position() == cur_b.position())
+                    .is_some_and(|prior_b| prior_b.position() == cur_b.position())
                 {
                     // the current bridge has not been advanced, so we just need to make
                     // sure that we have are tracking the marked leaf
@@ -800,7 +800,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                     if self
                         .prior_bridges
                         .last()
-                        .map_or(false, |pb| pb.position() == cur_b.position())
+                        .is_some_and(|pb| pb.position() == cur_b.position())
                     {
                         self.current_bridge = Some(cur_b);
                     } else {
@@ -858,16 +858,10 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
         position: Position,
         checkpoint_depth: usize,
     ) -> Result<Vec<H>, WitnessingError> {
-        #[derive(Debug)]
-        enum AuthBase<'a, C> {
-            Current,
-            Checkpoint(usize, &'a Checkpoint<C>),
-        }
-
-        // Find the earliest checkpoint having a matching root, or the current
-        // root if it matches and there is no earlier matching checkpoint.
+        // Find the earliest checkpoint having a matching root, or None (meaning the
+        // current root) if it matches and there is no earlier matching checkpoint.
         let auth_base = if checkpoint_depth == 0 {
-            Ok(AuthBase::Current)
+            Ok(None)
         } else if self.checkpoints.len() >= checkpoint_depth {
             let c_idx = self.checkpoints.len() - checkpoint_depth;
             if self
@@ -885,7 +879,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                 // created, so we can't treat it as marked.
                 Err(WitnessingError::PositionNotMarked(position))
             } else {
-                Ok(AuthBase::Checkpoint(c_idx, &self.checkpoints[c_idx]))
+                Ok(Some(&self.checkpoints[c_idx]))
             }
         } else {
             Err(WitnessingError::CheckpointInvalid)
@@ -903,7 +897,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
         // up to the specified checkpoint depth.
         let fuse_from = saved_idx + 1;
         let successor = match auth_base {
-            AuthBase::Current => {
+            None => {
                 // fuse all the way up to the current tip
                 MerkleBridge::fuse_all(
                     self.prior_bridges[fuse_from..]
@@ -913,13 +907,13 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                 .map(|fused| fused.unwrap()) // safe as the iterator being fused is nonempty
                 .map_err(WitnessingError::BridgeFusionError)
             }
-            AuthBase::Checkpoint(_, checkpoint) if fuse_from < checkpoint.bridges_len => {
+            Some(checkpoint) if fuse_from < checkpoint.bridges_len => {
                 // fuse from the provided checkpoint
                 MerkleBridge::fuse_all(self.prior_bridges[fuse_from..checkpoint.bridges_len].iter())
                     .map(|fused| fused.unwrap()) // safe as the iterator being fused is nonempty
                     .map_err(WitnessingError::BridgeFusionError)
             }
-            AuthBase::Checkpoint(_, checkpoint) if fuse_from == checkpoint.bridges_len => {
+            Some(checkpoint) if fuse_from == checkpoint.bridges_len => {
                 // The successor bridge should just be the empty successor to the
                 // checkpointed bridge.
                 if checkpoint.bridges_len > 0 {
@@ -928,7 +922,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                     Err(WitnessingError::CheckpointInvalid)
                 }
             }
-            AuthBase::Checkpoint(_, checkpoint) => {
+            Some(checkpoint) => {
                 // if the saved index is after the checkpoint, we can't generate
                 // an auth path
                 Err(WitnessingError::CheckpointTooDeep(

--- a/bridgetree/src/lib.rs
+++ b/bridgetree/src/lib.rs
@@ -34,10 +34,10 @@ pub use incrementalmerkletree::{
     frontier::{Frontier, NonEmptyFrontier},
     Address, Hashable, Level, Position, Retention, Source,
 };
-use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::ops::Range;
+use std::sync::OnceLock;
 
 /// Errors that can be discovered during checks that verify the compatibility of adjacent bridges.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -451,7 +451,7 @@ pub struct BridgeTree<H, C, const DEPTH: u8> {
     ///
     /// This field is purely a derived cache: it is excluded from equality and is not part of the
     /// tree's serialized form (reconstructed values start with an empty cache).
-    current_root: RefCell<Option<H>>,
+    current_root: OnceLock<H>,
 }
 
 impl<H: PartialEq, C: PartialEq, const DEPTH: u8> PartialEq for BridgeTree<H, C, DEPTH> {
@@ -502,7 +502,7 @@ impl<H, C, const DEPTH: u8> BridgeTree<H, C, DEPTH> {
             saved: BTreeMap::new(),
             checkpoints: VecDeque::new(),
             max_checkpoints,
-            current_root: RefCell::new(None),
+            current_root: OnceLock::new(),
         }
     }
 
@@ -572,7 +572,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
             saved: BTreeMap::new(),
             checkpoints: VecDeque::new(),
             max_checkpoints,
-            current_root: RefCell::new(None),
+            current_root: OnceLock::new(),
         }
     }
 
@@ -598,7 +598,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
             saved,
             checkpoints,
             max_checkpoints,
-            current_root: RefCell::new(None),
+            current_root: OnceLock::new(),
         })
     }
 
@@ -667,12 +667,12 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                 false
             } else {
                 bridge.append(value);
-                self.current_root.replace(None);
+                self.current_root.take();
                 true
             }
         } else {
             self.current_bridge = Some(MerkleBridge::new(value));
-            self.current_root.replace(None);
+            self.current_root.take();
             true
         }
     }
@@ -689,18 +689,14 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
             // queries between mutations — e.g. one consistency check per connected block, where
             // the common case is a block that appends no leaves — are then O(1) rather than
             // re-folding the frontier against empty subtree roots up to the full tree depth.
-            if let Some(cached) = self.current_root.borrow().as_ref() {
-                return Some(cached.clone());
-            }
-
-            let root = self
-                .current_bridge
-                .as_ref()
-                .map_or(H::empty_root(root_level), |bridge| {
-                    bridge.frontier().root(Some(root_level))
-                });
-            *self.current_root.borrow_mut() = Some(root.clone());
-            Some(root)
+            let root = self.current_root.get_or_init(|| {
+                self.current_bridge
+                    .as_ref()
+                    .map_or(H::empty_root(root_level), |bridge| {
+                        bridge.frontier().root(Some(root_level))
+                    })
+            });
+            Some(root.clone())
         } else if self.checkpoints.len() >= checkpoint_depth {
             let checkpoint_idx = self.checkpoints.len() - checkpoint_depth;
             self.checkpoints
@@ -847,7 +843,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                 .prior_bridges
                 .last()
                 .map(|b| b.successor(self.saved.contains_key(&b.position())));
-            self.current_root.replace(None);
+            self.current_root.take();
             true
         } else {
             false
@@ -1093,6 +1089,14 @@ mod tests {
             assert!(tree.append(c.to_string()))
         }
         assert!(!tree.append('i'.to_string()));
+    }
+
+    #[test]
+    fn bridgetree_is_send_and_sync() {
+        // The memoized root cache must keep `BridgeTree` both `Send` and `Sync`;
+        // a `RefCell`/`Cell` cache would silently make it `!Sync`.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<BridgeTree<String, usize, 8>>();
     }
 
     fn check_garbage_collect<H: Hashable + Clone + Ord + Debug, const DEPTH: u8>(

--- a/bridgetree/src/lib.rs
+++ b/bridgetree/src/lib.rs
@@ -34,6 +34,7 @@ pub use incrementalmerkletree::{
     frontier::{Frontier, NonEmptyFrontier},
     Address, Hashable, Level, Position, Retention, Source,
 };
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
 use std::ops::Range;
@@ -422,7 +423,7 @@ impl<C> Checkpoint<C> {
 
 /// A sparse representation of a Merkle tree with linear appending of leaves that contains enough
 /// information to produce a witness for any `mark`ed leaf.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct BridgeTree<H, C, const DEPTH: u8> {
     /// The ordered list of Merkle bridges representing the history
     /// of the tree. There will be one bridge for each saved leaf.
@@ -441,7 +442,30 @@ pub struct BridgeTree<H, C, const DEPTH: u8> {
     /// exceeded, the oldest checkpoint will be dropped when creating
     /// a new checkpoint.
     max_checkpoints: usize,
+    /// A memoized copy of the root of the current frontier (the root at checkpoint depth 0).
+    /// Computing this root requires hashing the frontier against empty subtree roots up to the
+    /// full depth of the tree, which is expensive relative to an append; since the frontier (and
+    /// therefore this root) changes only on `append` and `rewind`, we cache the value and clear
+    /// it in exactly those two operations. `checkpoint`, `mark`, `remove_mark`, and
+    /// `garbage_collect` all leave the frontier unchanged and so preserve the cache.
+    ///
+    /// This field is purely a derived cache: it is excluded from equality and is not part of the
+    /// tree's serialized form (reconstructed values start with an empty cache).
+    current_root: RefCell<Option<H>>,
 }
+
+impl<H: PartialEq, C: PartialEq, const DEPTH: u8> PartialEq for BridgeTree<H, C, DEPTH> {
+    fn eq(&self, other: &Self) -> bool {
+        // `current_root` is a derived cache and is deliberately not compared.
+        self.prior_bridges == other.prior_bridges
+            && self.current_bridge == other.current_bridge
+            && self.saved == other.saved
+            && self.checkpoints == other.checkpoints
+            && self.max_checkpoints == other.max_checkpoints
+    }
+}
+
+impl<H: Eq, C: Eq, const DEPTH: u8> Eq for BridgeTree<H, C, DEPTH> {}
 
 impl<H: Debug, C: Debug, const DEPTH: u8> Debug for BridgeTree<H, C, DEPTH> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -478,6 +502,7 @@ impl<H, C, const DEPTH: u8> BridgeTree<H, C, DEPTH> {
             saved: BTreeMap::new(),
             checkpoints: VecDeque::new(),
             max_checkpoints,
+            current_root: RefCell::new(None),
         }
     }
 
@@ -547,6 +572,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
             saved: BTreeMap::new(),
             checkpoints: VecDeque::new(),
             max_checkpoints,
+            current_root: RefCell::new(None),
         }
     }
 
@@ -572,6 +598,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
             saved,
             checkpoints,
             max_checkpoints,
+            current_root: RefCell::new(None),
         })
     }
 
@@ -640,10 +667,12 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                 false
             } else {
                 bridge.append(value);
+                self.current_root.replace(None);
                 true
             }
         } else {
             self.current_bridge = Some(MerkleBridge::new(value));
+            self.current_root.replace(None);
             true
         }
     }
@@ -655,13 +684,23 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
     pub fn root(&self, checkpoint_depth: usize) -> Option<H> {
         let root_level = Level::from(DEPTH);
         if checkpoint_depth == 0 {
-            Some(
-                self.current_bridge
-                    .as_ref()
-                    .map_or(H::empty_root(root_level), |bridge| {
-                        bridge.frontier().root(Some(root_level))
-                    }),
-            )
+            // The root of the current frontier is memoized in `current_root`, which is cleared by
+            // `append` and `rewind` (the only operations that change the frontier). Repeated
+            // queries between mutations — e.g. one consistency check per connected block, where
+            // the common case is a block that appends no leaves — are then O(1) rather than
+            // re-folding the frontier against empty subtree roots up to the full tree depth.
+            if let Some(cached) = self.current_root.borrow().as_ref() {
+                return Some(cached.clone());
+            }
+
+            let root = self
+                .current_bridge
+                .as_ref()
+                .map_or(H::empty_root(root_level), |bridge| {
+                    bridge.frontier().root(Some(root_level))
+                });
+            *self.current_root.borrow_mut() = Some(root.clone());
+            Some(root)
         } else if self.checkpoints.len() >= checkpoint_depth {
             let checkpoint_idx = self.checkpoints.len() - checkpoint_depth;
             self.checkpoints
@@ -808,6 +847,7 @@ impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C
                 .prior_bridges
                 .last()
                 .map(|b| b.successor(self.saved.contains_key(&b.position())));
+            self.current_root.replace(None);
             true
         } else {
             false


### PR DESCRIPTION
Release `bridgetree 0.7.1`.

### Optimization

`BridgeTree::root(0)` re-folds the current frontier against empty subtree roots up to the full depth of the tree on every call. For consumers that query the root once per tree mutation —e.g. a per-block consistency check where the common case is a block that appends no leaves— this fixed per-call cost dominates.

Cache the depth-0 root and clear it in `append` and `rewind`, the only operations that change the frontier. `checkpoint`, `mark`, `remove_mark`, and `garbage_collect` preserve the frontier and so preserve the cache, so the cache survives across the checkpoint that bounds each block when that block appends no leaves. Repeated root queries between mutations are now O(1).

### Changed

The MSRV is raised from 1.64 to 1.70 in order to use `std::sync::OnceLock`.