### PR TITLE
shardtree: discard stale cap roots on truncation

### DIFF
--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to Rust's notion of
   retained anchors interleaved with the checkpoints being pruned. Repeated
   checkpoints sharing a tree position, as a stalled chain produces, triggered it
   within a single pruning window.
+- Checkpoint truncation now discards cached cap roots that commit to positions
+  beyond the checkpoint, so replacement commitments produce the correct root.
 
 
 ## [0.6.2] - 2026-02-20

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -870,18 +870,16 @@ impl<
                     .map_err(ShardTreeError::Storage)?
                     .and_then(|s| s.truncate_to_position(position));
 
-                let cap_tree = LocatedTree {
-                    root_addr: Self::root_addr(),
-                    root: self.store.get_cap().map_err(ShardTreeError::Storage)?,
-                };
+                if let Some(truncated) = replacement {
+                    let truncated_cap = LocatedTree {
+                        root_addr: Self::root_addr(),
+                        root: self.store.get_cap().map_err(ShardTreeError::Storage)?,
+                    }
+                    .truncate_cache_to_position(position);
 
-                if let Some(truncated_cap) = cap_tree.truncate_to_position(position) {
                     self.store
                         .put_cap(truncated_cap.root)
                         .map_err(ShardTreeError::Storage)?;
-                };
-
-                if let Some(truncated) = replacement {
                     self.store
                         .truncate_shards(subtree_addr.index())
                         .map_err(ShardTreeError::Storage)?;
@@ -2622,6 +2620,84 @@ mod tests {
         assert!(
             LocatedTree::from_parts(shifted_root_addr, cap).is_ok(),
             "Cap must not contain Parent nodes at or below shard level"
+        );
+    }
+
+    #[test]
+    fn truncate_clears_cap_hashes_beyond_checkpoint() {
+        fn insert_first_shard(tree: &mut ShardTree<MemoryShardStore<String, u32>, 6, 3>) {
+            tree.batch_insert(
+                Position::from(0),
+                ('a'..='h').map(|c| {
+                    (
+                        c.to_string(),
+                        if c == 'h' {
+                            Retention::Checkpoint {
+                                id: 1,
+                                marking: Marking::None,
+                            }
+                        } else {
+                            Retention::Ephemeral
+                        },
+                    )
+                }),
+            )
+            .unwrap();
+        }
+
+        let mut tree: ShardTree<MemoryShardStore<String, u32>, 6, 3> =
+            ShardTree::new(MemoryShardStore::empty(), 100);
+
+        // Simulate imported subtree roots and cache their combined hash.
+        tree.insert(
+            Address::from_parts(Level::from(3), 0),
+            "abcdefgh".to_string(),
+        )
+        .unwrap();
+        tree.insert(
+            Address::from_parts(Level::from(3), 1),
+            "ijklmnop".to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            tree.root_caching(
+                ShardTree::<MemoryShardStore<String, u32>, 6, 3>::root_addr(),
+                Position::from(16),
+            ),
+            Ok(format!("abcdefghijklmnop{}", "_".repeat(48)))
+        );
+
+        // Scanning replaces the first imported shard root with its leaves and records a
+        // checkpoint at the end of that shard.
+        insert_first_shard(&mut tree);
+
+        assert_eq!(tree.truncate_to_checkpoint(&1), Ok(true));
+
+        // The imported root committed to both shards. After truncation, inserting a
+        // replacement second shard must not reuse that stale cached root.
+        tree.insert(
+            Address::from_parts(Level::from(3), 1),
+            "IJKLMNOP".to_string(),
+        )
+        .unwrap();
+        let expected_root = format!("abcdefghIJKLMNOP{}", "_".repeat(48));
+        assert_eq!(
+            tree.root_at_checkpoint_depth(None),
+            Ok(Some(expected_root.clone()))
+        );
+
+        let mut reference: ShardTree<MemoryShardStore<String, u32>, 6, 3> =
+            ShardTree::new(MemoryShardStore::empty(), 100);
+        insert_first_shard(&mut reference);
+        reference
+            .insert(
+                Address::from_parts(Level::from(3), 1),
+                "IJKLMNOP".to_string(),
+            )
+            .unwrap();
+        assert_eq!(
+            reference.root_at_checkpoint_depth(None),
+            Ok(Some(expected_root))
         );
     }
 

--- a/shardtree/src/prunable.rs
+++ b/shardtree/src/prunable.rs
@@ -789,6 +789,53 @@ where
         }
     }
 
+    /// Removes cached nodes and annotations that commit to positions beyond `position`.
+    ///
+    /// Unlike [`Self::truncate_to_position`], this may discard a cached leaf that spans the
+    /// boundary because the underlying shard data remains authoritative.
+    pub(crate) fn truncate_cache_to_position(&self, position: Position) -> Self {
+        /// Pre-condition: `root_addr` must be the address of `root`.
+        fn go<H>(position: Position, root_addr: Address, root: &PrunableTree<H>) -> PrunableTree<H>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
+            if position < root_addr.position_range_start() {
+                Tree::empty()
+            } else if root_addr.max_position() <= position {
+                root.clone()
+            } else {
+                match &root.0 {
+                    Node::Parent { left, right, .. } => {
+                        let (l_child, r_child) = root_addr
+                            .children()
+                            .expect("has children because we checked `root` is a parent");
+                        if position < r_child.position_range_start() {
+                            Tree::unite(
+                                l_child.level(),
+                                None,
+                                go(position, l_child, left.as_ref()),
+                                Tree::empty(),
+                            )
+                        } else {
+                            Tree::unite(
+                                l_child.level(),
+                                None,
+                                left.as_ref().clone(),
+                                go(position, r_child, right.as_ref()),
+                            )
+                        }
+                    }
+                    Node::Leaf { .. } | Node::Nil => Tree::empty(),
+                }
+            }
+        }
+
+        LocatedTree {
+            root_addr: self.root_addr,
+            root: go(position, self.root_addr, &self.root),
+        }
+    }
+
     /// Inserts a descendant subtree into this subtree, creating empty sibling nodes as necessary
     /// to fill out the tree.
     ///
@@ -1304,6 +1351,7 @@ fn accumulate_result_with<A, B, C>(
 mod tests {
     use assert_matches::assert_matches;
     use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::Arc;
 
     use incrementalmerkletree::{frontier::NonEmptyFrontier, Address, Level, Position};
     use proptest::proptest;
@@ -1315,7 +1363,7 @@ mod tests {
         testing::{arb_char_str, arb_prunable_tree},
         tree::{
             tests::{leaf, nil, parent},
-            LocatedTree,
+            LocatedTree, Tree,
         },
     };
 
@@ -1386,6 +1434,65 @@ mod tests {
                 leaf(("c".to_string(), RetentionFlags::MARKED)),
                 leaf(("ab".to_string(), RetentionFlags::EPHEMERAL))
             )
+        );
+    }
+
+    #[test]
+    fn truncate_cache_to_position_discards_nodes_that_span_cut() {
+        let root_addr = Address::from_parts(2.into(), 0);
+        let tree: LocatedPrunableTree<String> = LocatedTree {
+            root_addr,
+            root: parent(
+                parent(
+                    leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+                leaf(("cd".to_string(), RetentionFlags::EPHEMERAL)),
+            ),
+        };
+        assert_eq!(
+            tree.truncate_cache_to_position(Position::from(2)),
+            LocatedTree {
+                root_addr,
+                root: parent(
+                    parent(
+                        leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                        leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                    ),
+                    nil(),
+                ),
+            }
+        );
+
+        let annotated: LocatedPrunableTree<String> = LocatedTree {
+            root_addr,
+            root: Tree::parent(
+                Some(Arc::new("abcd".to_string())),
+                Tree::parent(
+                    Some(Arc::new("ab".to_string())),
+                    leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+                parent(
+                    leaf(("c".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("d".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+            ),
+        };
+        assert_eq!(
+            annotated.truncate_cache_to_position(Position::from(2)),
+            LocatedTree {
+                root_addr,
+                root: Tree::parent(
+                    None,
+                    Tree::parent(
+                        Some(Arc::new("ab".to_string())),
+                        leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                        leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                    ),
+                    parent(leaf(("c".to_string(), RetentionFlags::EPHEMERAL)), nil()),
+                ),
+            }
         );
     }
 


### PR DESCRIPTION
Checkpoint truncation could retain a cached cap hash covering positions after the target checkpoint. After inserting replacement commitments, root queries could return the pre-truncation root.

The cap is non-authoritative: shard data remains the source of truth. This change retains cache nodes wholly before the checkpoint and discards cached leaves and parent annotations that cross its boundary, forcing later root queries to recompute from the retained and replacement shards.

Shard and checkpoint truncation semantics are unchanged. The regression reproduces the relevant wallet sequence through public `ShardTree` operations: insert subtree roots, cache their combined root, scan to a valid checkpoint, truncate, and insert replacement commitments.