### PR TITLE
Move type constraints to where clauses

### DIFF
--- a/bridgetree/src/lib.rs
+++ b/bridgetree/src/lib.rs
@@ -186,7 +186,10 @@ impl<H> MerkleBridge<H> {
     }
 }
 
-impl<'a, H: Hashable + Clone + Ord + 'a> MerkleBridge<H> {
+impl<'a, H> MerkleBridge<H>
+where
+    H: Hashable + Clone + Ord + 'a,
+{
     /// Constructs a new bridge to follow this one. If `mark_current_leaf` is true, the successor
     /// will track the information necessary to create a witness for the leaf most
     /// recently appended to this bridge's frontier.
@@ -270,9 +273,10 @@ impl<'a, H: Hashable + Clone + Ord + 'a> MerkleBridge<H> {
     /// of all the provided bridges (discarding internal frontiers) or None
     /// if the provided iterator is empty. Returns a continuity error if
     /// any of the bridges are not valid successors to one another.
-    fn fuse_all<T: Iterator<Item = &'a Self>>(
-        mut iter: T,
-    ) -> Result<Option<Self>, ContinuityError> {
+    fn fuse_all<T>(mut iter: T) -> Result<Option<Self>, ContinuityError>
+    where
+        T: Iterator<Item = &'a Self>,
+    {
         let mut fused = iter.next().cloned();
         for next in iter {
             fused = Some(fused.unwrap().fuse(next)?);
@@ -406,7 +410,10 @@ impl<C> Checkpoint<C> {
 
     // A private convenience method that returns the position of the bridge corresponding
     // to this checkpoint, if the checkpoint is not for the empty bridge.
-    fn position<H: Ord>(&self, bridges: &[MerkleBridge<H>]) -> Option<Position> {
+    fn position<H>(&self, bridges: &[MerkleBridge<H>]) -> Option<Position>
+    where
+        H: Ord,
+    {
         if self.bridges_len == 0 {
             None
         } else {
@@ -416,7 +423,10 @@ impl<C> Checkpoint<C> {
 
     // A private method that rewrites the indices of each forgotten marked record
     // using the specified rewrite function. Used during garbage collection.
-    fn rewrite_indices<F: Fn(usize) -> usize>(&mut self, f: F) {
+    fn rewrite_indices<F>(&mut self, f: F)
+    where
+        F: Fn(usize) -> usize,
+    {
         self.bridges_len = f(self.bridges_len);
     }
 }
@@ -454,7 +464,11 @@ pub struct BridgeTree<H, C, const DEPTH: u8> {
     current_root: OnceLock<H>,
 }
 
-impl<H: PartialEq, C: PartialEq, const DEPTH: u8> PartialEq for BridgeTree<H, C, DEPTH> {
+impl<H, C, const DEPTH: u8> PartialEq for BridgeTree<H, C, DEPTH>
+where
+    H: PartialEq,
+    C: PartialEq,
+{
     fn eq(&self, other: &Self) -> bool {
         // `current_root` is a derived cache and is deliberately not compared.
         self.prior_bridges == other.prior_bridges
@@ -465,9 +479,18 @@ impl<H: PartialEq, C: PartialEq, const DEPTH: u8> PartialEq for BridgeTree<H, C,
     }
 }
 
-impl<H: Eq, C: Eq, const DEPTH: u8> Eq for BridgeTree<H, C, DEPTH> {}
+impl<H, C, const DEPTH: u8> Eq for BridgeTree<H, C, DEPTH>
+where
+    H: Eq,
+    C: Eq,
+{
+}
 
-impl<H: Debug, C: Debug, const DEPTH: u8> Debug for BridgeTree<H, C, DEPTH> {
+impl<H, C, const DEPTH: u8> Debug for BridgeTree<H, C, DEPTH>
+where
+    H: Debug,
+    C: Debug,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
@@ -557,7 +580,11 @@ impl<H, C, const DEPTH: u8> BridgeTree<H, C, DEPTH> {
     }
 }
 
-impl<H: Hashable + Clone + Ord, C: Clone + Ord, const DEPTH: u8> BridgeTree<H, C, DEPTH> {
+impl<H, C, const DEPTH: u8> BridgeTree<H, C, DEPTH>
+where
+    H: Hashable + Clone + Ord,
+    C: Clone + Ord,
+{
     /// Construct a new BridgeTree that will start recording changes from the state of
     /// the specified frontier.
     pub fn from_frontier(max_checkpoints: usize, frontier: NonEmptyFrontier<H>) -> Self {
@@ -1023,8 +1050,9 @@ mod tests {
         complete_tree::CompleteTree, CombinedTree, SipHashable,
     };
 
-    impl<H: Hashable + Clone + Ord, const DEPTH: u8> testing::Tree<H, usize>
-        for BridgeTree<H, usize, DEPTH>
+    impl<H, const DEPTH: u8> testing::Tree<H, usize> for BridgeTree<H, usize, DEPTH>
+    where
+        H: Hashable + Clone + Ord,
     {
         fn append(&mut self, value: H, retention: Retention<usize>) -> bool {
             let appended = BridgeTree::append(self, value);
@@ -1089,13 +1117,18 @@ mod tests {
     fn bridgetree_is_send_and_sync() {
         // The memoized root cache must keep `BridgeTree` both `Send` and `Sync`;
         // a `RefCell`/`Cell` cache would silently make it `!Sync`.
-        fn assert_send_sync<T: Send + Sync>() {}
+        fn assert_send_sync<T>()
+        where
+            T: Send + Sync,
+        {
+        }
         assert_send_sync::<BridgeTree<String, usize, 8>>();
     }
 
-    fn check_garbage_collect<H: Hashable + Clone + Ord + Debug, const DEPTH: u8>(
-        mut tree: BridgeTree<H, usize, DEPTH>,
-    ) {
+    fn check_garbage_collect<H, const DEPTH: u8>(mut tree: BridgeTree<H, usize, DEPTH>)
+    where
+        H: Hashable + Clone + Ord + Debug,
+    {
         // Add checkpoints until we're sure everything that can be gc'ed will be gc'ed
         for i in 0..tree.max_checkpoints {
             tree.checkpoint(i + 1);
@@ -1109,11 +1142,12 @@ mod tests {
         }
     }
 
-    fn arb_bridgetree<G: Strategy + Clone>(
+    fn arb_bridgetree<G>(
         item_gen: G,
         max_count: usize,
     ) -> impl Strategy<Value = BridgeTree<G::Value, usize, 8>>
     where
+        G: Strategy + Clone,
         G::Value: Hashable + Clone + Ord + Debug + 'static,
     {
         let pos_gen = (0..max_count).prop_map(|p| Position::try_from(p).unwrap());
@@ -1230,9 +1264,12 @@ mod tests {
     }
 
     // Combined tree tests
-    fn new_combined_tree<H: Hashable + Clone + Ord + Debug>(
+    fn new_combined_tree<H>(
         max_checkpoints: usize,
-    ) -> CombinedTree<H, usize, CompleteTree<H, usize, 4>, BridgeTree<H, usize, 4>> {
+    ) -> CombinedTree<H, usize, CompleteTree<H, usize, 4>, BridgeTree<H, usize, 4>>
+    where
+        H: Hashable + Clone + Ord + Debug,
+    {
         CombinedTree::new(
             CompleteTree::<H, usize, 4>::new(max_checkpoints),
             BridgeTree::<H, usize, 4>::new(max_checkpoints),

--- a/incrementalmerkletree-testing/src/complete_tree.rs
+++ b/incrementalmerkletree-testing/src/complete_tree.rs
@@ -7,7 +7,10 @@ use incrementalmerkletree::{Hashable, Level, Marking, Position, Retention};
 
 const MAX_COMPLETE_SIZE_ERROR: &str = "Positions of a `CompleteTree` must fit into the platform word size, because larger complete trees are not representable.";
 
-pub(crate) fn root<H: Hashable + Clone>(leaves: &[H], depth: u8) -> H {
+pub(crate) fn root<H>(leaves: &[H], depth: u8) -> H
+where
+    H: Hashable + Clone,
+{
     let empty_leaf = H::empty_leaf();
     let mut leaves = leaves
         .iter()
@@ -63,14 +66,21 @@ impl Checkpoint {
 }
 
 #[derive(Clone, Debug)]
-pub struct CompleteTree<H, C: Ord, const DEPTH: u8> {
+pub struct CompleteTree<H, C, const DEPTH: u8>
+where
+    C: Ord,
+{
     leaves: Vec<Option<H>>,
     marks: BTreeSet<Position>,
     checkpoints: BTreeMap<C, Checkpoint>,
     max_checkpoints: usize,
 }
 
-impl<H: Hashable, C: Clone + Ord + core::fmt::Debug, const DEPTH: u8> CompleteTree<H, C, DEPTH> {
+impl<H, C, const DEPTH: u8> CompleteTree<H, C, DEPTH>
+where
+    H: Hashable,
+    C: Clone + Ord + core::fmt::Debug,
+{
     /// Creates a new, empty binary tree
     pub fn new(max_checkpoints: usize) -> Self {
         Self {
@@ -207,8 +217,10 @@ enum AppendError<C> {
     },
 }
 
-impl<H: Hashable + PartialEq + Clone, C: Ord + Clone + core::fmt::Debug, const DEPTH: u8> Tree<H, C>
-    for CompleteTree<H, C, DEPTH>
+impl<H, C, const DEPTH: u8> Tree<H, C> for CompleteTree<H, C, DEPTH>
+where
+    H: Hashable + PartialEq + Clone,
+    C: Ord + Clone + core::fmt::Debug,
 {
     fn depth(&self) -> u8 {
         DEPTH

--- a/incrementalmerkletree-testing/src/lib.rs
+++ b/incrementalmerkletree-testing/src/lib.rs
@@ -149,8 +149,15 @@ pub fn witness<H, C>(pos: u64, depth: usize) -> Operation<H, C> {
     Operation::Witness(Position::from(pos), depth)
 }
 
-impl<H: Hashable + Clone, C: Clone> Operation<H, C> {
-    pub fn apply<T: Tree<H, C>>(&self, tree: &mut T) -> Option<(Position, Vec<H>)> {
+impl<H, C> Operation<H, C>
+where
+    H: Hashable + Clone,
+    C: Clone,
+{
+    pub fn apply<T>(&self, tree: &mut T) -> Option<(Position, Vec<H>)>
+    where
+        T: Tree<H, C>,
+    {
         match self {
             Append(a, r) => {
                 assert!(tree.append(a.clone(), r.clone()), "append failed");
@@ -176,10 +183,10 @@ impl<H: Hashable + Clone, C: Clone> Operation<H, C> {
         }
     }
 
-    pub fn apply_all<T: Tree<H, C>>(
-        ops: &[Operation<H, C>],
-        tree: &mut T,
-    ) -> Option<(Position, Vec<H>)> {
+    pub fn apply_all<T>(ops: &[Operation<H, C>], tree: &mut T) -> Option<(Position, Vec<H>)>
+    where
+        T: Tree<H, C>,
+    {
         let mut result = None;
         for op in ops {
             result = op.apply(tree);
@@ -187,7 +194,10 @@ impl<H: Hashable + Clone, C: Clone> Operation<H, C> {
         result
     }
 
-    pub fn map_checkpoint_id<D, F: Fn(&C) -> D>(&self, f: F) -> Operation<H, D> {
+    pub fn map_checkpoint_id<D, F>(&self, f: F) -> Operation<H, D>
+    where
+        F: Fn(&C) -> D,
+    {
         match self {
             Append(a, r) => Append(a.clone(), r.map(f)),
             CurrentPosition => CurrentPosition,
@@ -222,11 +232,12 @@ pub fn arb_retention() -> impl Strategy<Value = Retention<()>> {
     ]
 }
 
-pub fn arb_operation<G: Strategy + Clone>(
+pub fn arb_operation<G>(
     item_gen: G,
     pos_gen: impl Strategy<Value = Position> + Clone,
 ) -> impl Strategy<Value = Operation<G::Value, ()>>
 where
+    G: Strategy + Clone,
     G::Value: Clone + 'static,
 {
     prop_oneof![
@@ -244,7 +255,10 @@ where
     ]
 }
 
-pub fn apply_operation<H, C, T: Tree<H, C>>(tree: &mut T, op: Operation<H, C>) {
+pub fn apply_operation<H, C, T>(tree: &mut T, op: Operation<H, C>)
+where
+    T: Tree<H, C>,
+{
     match op {
         Append(value, r) => {
             tree.append(value, r);
@@ -266,10 +280,12 @@ pub fn apply_operation<H, C, T: Tree<H, C>>(tree: &mut T, op: Operation<H, C>) {
     }
 }
 
-pub fn check_operations<H: Hashable + Ord + Clone + Debug, C: Clone, T: Tree<H, C>>(
-    mut tree: T,
-    ops: &[Operation<H, C>],
-) -> Result<(), TestCaseError> {
+pub fn check_operations<H, C, T>(mut tree: T, ops: &[Operation<H, C>]) -> Result<(), TestCaseError>
+where
+    H: Hashable + Ord + Clone + Debug,
+    C: Clone,
+    T: Tree<H, C>,
+{
     let mut tree_size = 0;
     let mut tree_values: Vec<H> = vec![];
     // the number of leaves in the tree at the time that a checkpoint is made
@@ -359,7 +375,10 @@ pub fn check_operations<H: Hashable + Ord + Clone + Debug, C: Clone, T: Tree<H, 
     Ok(())
 }
 
-pub fn compute_root_from_witness<H: Hashable>(value: H, position: Position, path: &[H]) -> H {
+pub fn compute_root_from_witness<H>(value: H, position: Position, path: &[H]) -> H
+where
+    H: Hashable,
+{
     let mut cur = value;
     let mut lvl = 0.into();
     for (i, v) in path
@@ -382,14 +401,23 @@ pub fn compute_root_from_witness<H: Hashable>(value: H, position: Position, path
 //
 
 #[derive(Clone, Debug)]
-pub struct CombinedTree<H, C, I: Tree<H, C>, E: Tree<H, C>> {
+pub struct CombinedTree<H, C, I, E>
+where
+    I: Tree<H, C>,
+    E: Tree<H, C>,
+{
     inefficient: I,
     efficient: E,
     _phantom_h: PhantomData<H>,
     _phantom_c: PhantomData<C>,
 }
 
-impl<H: Hashable + Ord + Clone + Debug, C, I: Tree<H, C>, E: Tree<H, C>> CombinedTree<H, C, I, E> {
+impl<H, C, I, E> CombinedTree<H, C, I, E>
+where
+    H: Hashable + Ord + Clone + Debug,
+    I: Tree<H, C>,
+    E: Tree<H, C>,
+{
     pub fn new(inefficient: I, efficient: E) -> Self {
         assert_eq!(inefficient.depth(), efficient.depth());
         CombinedTree {
@@ -401,8 +429,12 @@ impl<H: Hashable + Ord + Clone + Debug, C, I: Tree<H, C>, E: Tree<H, C>> Combine
     }
 }
 
-impl<H: Hashable + Ord + Clone + Debug, C: Clone, I: Tree<H, C>, E: Tree<H, C>> Tree<H, C>
-    for CombinedTree<H, C, I, E>
+impl<H, C, I, E> Tree<H, C> for CombinedTree<H, C, I, E>
+where
+    H: Hashable + Ord + Clone + Debug,
+    C: Clone,
+    I: Tree<H, C>,
+    E: Tree<H, C>,
 {
     fn depth(&self) -> u8 {
         self.inefficient.depth()
@@ -517,7 +549,11 @@ impl TestCheckpoint for usize {
     }
 }
 
-trait TestTree<H: TestHashable, C: TestCheckpoint> {
+trait TestTree<H, C>
+where
+    H: TestHashable,
+    C: TestCheckpoint,
+{
     fn assert_root(&self, checkpoint_depth: Option<usize>, values: &[u64]);
 
     fn assert_append(&mut self, value: u64, retention: Retention<u64>);
@@ -525,7 +561,12 @@ trait TestTree<H: TestHashable, C: TestCheckpoint> {
     fn assert_checkpoint(&mut self, value: u64);
 }
 
-impl<H: TestHashable, C: TestCheckpoint, T: Tree<H, C>> TestTree<H, C> for T {
+impl<H, C, T> TestTree<H, C> for T
+where
+    H: TestHashable,
+    C: TestCheckpoint,
+    T: Tree<H, C>,
+{
     fn assert_root(&self, checkpoint_depth: Option<usize>, values: &[u64]) {
         assert_eq!(
             self.root(checkpoint_depth).unwrap(),
@@ -551,9 +592,13 @@ impl<H: TestHashable, C: TestCheckpoint, T: Tree<H, C>> TestTree<H, C> for T {
 }
 
 /// This checks basic append and root computation functionality
-pub fn check_root_hashes<H: TestHashable, C: TestCheckpoint, T: Tree<H, C>, F: Fn(usize) -> T>(
-    new_tree: F,
-) {
+pub fn check_root_hashes<H, C, T, F>(new_tree: F)
+where
+    H: TestHashable,
+    C: TestCheckpoint,
+    T: Tree<H, C>,
+    F: Fn(usize) -> T,
+{
     use Retention::*;
 
     {
@@ -585,9 +630,13 @@ pub fn check_root_hashes<H: TestHashable, C: TestCheckpoint, T: Tree<H, C>, F: F
 
 /// This test expects a depth-4 tree and verifies that the tree reports itself as full after 2^4
 /// appends.
-pub fn check_append<H: TestHashable, C: TestCheckpoint, T: Tree<H, C>, F: Fn(usize) -> T>(
-    new_tree: F,
-) {
+pub fn check_append<H, C, T, F>(new_tree: F)
+where
+    H: TestHashable,
+    C: TestCheckpoint,
+    T: Tree<H, C>,
+    F: Fn(usize) -> T,
+{
     use Retention::*;
 
     {
@@ -615,9 +664,13 @@ pub fn check_append<H: TestHashable, C: TestCheckpoint, T: Tree<H, C>, F: Fn(usi
     }
 }
 
-pub fn check_witnesses<H: TestHashable, C: TestCheckpoint, T: Tree<H, C>, F: Fn(usize) -> T>(
-    new_tree: F,
-) {
+pub fn check_witnesses<H, C, T, F>(new_tree: F)
+where
+    H: TestHashable,
+    C: TestCheckpoint,
+    T: Tree<H, C>,
+    F: Fn(usize) -> T,
+{
     use Retention::*;
 
     {
@@ -1018,9 +1071,12 @@ pub fn check_witnesses<H: TestHashable, C: TestCheckpoint, T: Tree<H, C>, F: Fn(
     }
 }
 
-pub fn check_checkpoint_rewind<C: TestCheckpoint, T: Tree<String, C>, F: Fn(usize) -> T>(
-    new_tree: F,
-) {
+pub fn check_checkpoint_rewind<C, T, F>(new_tree: F)
+where
+    C: TestCheckpoint,
+    T: Tree<String, C>,
+    F: Fn(usize) -> T,
+{
     let mut t = new_tree(100);
     assert!(!t.rewind(0));
 
@@ -1061,7 +1117,12 @@ pub fn check_checkpoint_rewind<C: TestCheckpoint, T: Tree<String, C>, F: Fn(usiz
     assert_eq!(t.root(None).unwrap(), "ab______________");
 }
 
-pub fn check_remove_mark<C: TestCheckpoint, T: Tree<String, C>, F: Fn(usize) -> T>(new_tree: F) {
+pub fn check_remove_mark<C, T, F>(new_tree: F)
+where
+    C: TestCheckpoint,
+    T: Tree<String, C>,
+    F: Fn(usize) -> T,
+{
     let samples = [
         vec![
             append_str("a", Retention::Ephemeral),
@@ -1096,9 +1157,12 @@ pub fn check_remove_mark<C: TestCheckpoint, T: Tree<String, C>, F: Fn(usize) -> 
     }
 }
 
-pub fn check_rewind_remove_mark<C: TestCheckpoint, T: Tree<String, C>, F: Fn(usize) -> T>(
-    new_tree: F,
-) {
+pub fn check_rewind_remove_mark<C, T, F>(new_tree: F)
+where
+    C: TestCheckpoint,
+    T: Tree<String, C>,
+    F: Fn(usize) -> T,
+{
     // rewinding doesn't remove a mark
     let mut tree = new_tree(100);
     tree.append("e".to_string(), Retention::Marked);
@@ -1176,9 +1240,12 @@ pub fn check_rewind_remove_mark<C: TestCheckpoint, T: Tree<String, C>, F: Fn(usi
     }
 }
 
-pub fn check_witness_consistency<C: TestCheckpoint, T: Tree<String, C>, F: Fn(usize) -> T>(
-    new_tree: F,
-) {
+pub fn check_witness_consistency<C, T, F>(new_tree: F)
+where
+    C: TestCheckpoint,
+    T: Tree<String, C>,
+    F: Fn(usize) -> T,
+{
     let samples = vec![
         // Reduced examples
         vec![

--- a/incrementalmerkletree/src/frontier.rs
+++ b/incrementalmerkletree/src/frontier.rs
@@ -85,7 +85,10 @@ impl<H> NonEmptyFrontier<H> {
     }
 }
 
-impl<H: Hashable + Clone> NonEmptyFrontier<H> {
+impl<H> NonEmptyFrontier<H>
+where
+    H: Hashable + Clone,
+{
     /// Append a new leaf to the frontier, and recompute ommers by hashing together full subtrees
     /// until an empty ommer slot is found.
     pub fn append(&mut self, leaf: H) {
@@ -186,12 +189,16 @@ impl<H: Hashable + Clone> NonEmptyFrontier<H> {
 }
 
 #[cfg(any(test, feature = "test-dependencies"))]
-impl<H: Hashable + Clone> NonEmptyFrontier<H>
+impl<H> NonEmptyFrontier<H>
 where
+    H: Hashable + Clone,
     Standard: Distribution<H>,
 {
     /// Generates a random frontier of a Merkle tree having the specified nonzero size.
-    pub fn random_of_size<R: RngCore>(rng: &mut R, tree_size: NonZeroU64) -> Self {
+    pub fn random_of_size<R>(rng: &mut R, tree_size: NonZeroU64) -> Self
+    where
+        R: RngCore,
+    {
         let position = (u64::from(tree_size) - 1).into();
         NonEmptyFrontier::from_parts(
             position,
@@ -203,11 +210,14 @@ where
         .unwrap()
     }
 
-    pub fn random_with_prior_subtree_roots<R: RngCore>(
+    pub fn random_with_prior_subtree_roots<R>(
         rng: &mut R,
         tree_size: NonZeroU64,
         subtree_depth: NonZeroU8,
-    ) -> (Vec<H>, Self) {
+    ) -> (Vec<H>, Self)
+    where
+        R: RngCore,
+    {
         let prior_subtree_count: u64 = u64::from(tree_size) >> u8::from(subtree_depth);
         if prior_subtree_count > 0 {
             let prior_roots: Vec<H> = core::iter::repeat_with(|| rng.gen())
@@ -328,7 +338,10 @@ impl<H, const DEPTH: u8> Frontier<H, DEPTH> {
     }
 }
 
-impl<H: Hashable + Clone, const DEPTH: u8> Frontier<H, DEPTH> {
+impl<H, const DEPTH: u8> Frontier<H, DEPTH>
+where
+    H: Hashable + Clone,
+{
     /// Appends a new value to the frontier at the next available slot.
     /// Returns true if successful and false if the frontier would exceed
     /// the maximum allowed depth.
@@ -382,12 +395,16 @@ impl<H: Hashable + Clone, const DEPTH: u8> Frontier<H, DEPTH> {
 }
 
 #[cfg(any(test, feature = "test-dependencies"))]
-impl<H: Hashable + Clone, const DEPTH: u8> Frontier<H, DEPTH>
+impl<H, const DEPTH: u8> Frontier<H, DEPTH>
 where
+    H: Hashable + Clone,
     Standard: Distribution<H>,
 {
     /// Generates a random frontier of a Merkle tree having the specified size.
-    pub fn random_of_size<R: RngCore>(rng: &mut R, tree_size: u64) -> Self {
+    pub fn random_of_size<R>(rng: &mut R, tree_size: u64) -> Self
+    where
+        R: RngCore,
+    {
         assert!(tree_size <= 2u64.checked_pow(DEPTH.into()).unwrap());
         Frontier {
             frontier: NonZeroU64::new(tree_size)
@@ -395,11 +412,14 @@ where
         }
     }
 
-    pub fn random_with_prior_subtree_roots<R: RngCore>(
+    pub fn random_with_prior_subtree_roots<R>(
         rng: &mut R,
         tree_size: u64,
         subtree_depth: NonZeroU8,
-    ) -> (Vec<H>, Self) {
+    ) -> (Vec<H>, Self)
+    where
+        R: RngCore,
+    {
         assert!(tree_size <= 2u64.checked_pow(DEPTH.into()).unwrap());
         NonZeroU64::new(tree_size).map_or((vec![], Frontier::empty()), |tree_size| {
             let (prior_roots, frontier) =
@@ -421,7 +441,10 @@ pub struct PathFiller<H> {
 }
 
 #[cfg(feature = "legacy-api")]
-impl<H: Hashable> PathFiller<H> {
+impl<H> PathFiller<H>
+where
+    H: Hashable,
+{
     pub fn empty() -> Self {
         PathFiller {
             queue: VecDeque::new(),
@@ -543,7 +566,10 @@ impl<H, const DEPTH: u8> CommitmentTree<H, DEPTH> {
 }
 
 #[cfg(feature = "legacy-api")]
-impl<H: Hashable + Clone, const DEPTH: u8> CommitmentTree<H, DEPTH> {
+impl<H, const DEPTH: u8> CommitmentTree<H, DEPTH>
+where
+    H: Hashable + Clone,
+{
     pub fn from_frontier(frontier: &Frontier<H, DEPTH>) -> Self {
         frontier.value().map_or_else(Self::empty, |f| {
             let mut ommers_iter = f.ommers().iter().cloned();
@@ -686,8 +712,9 @@ pub mod testing {
 
     use crate::{frontier::Frontier, Hashable, Level};
 
-    impl<H: Hashable + Clone, const DEPTH: u8> crate::testing::Frontier<H>
-        for super::Frontier<H, DEPTH>
+    impl<H, const DEPTH: u8> crate::testing::Frontier<H> for super::Frontier<H, DEPTH>
+    where
+        H: Hashable + Clone,
     {
         fn append(&mut self, value: H) -> bool {
             super::Frontier::append(self, value)
@@ -717,7 +744,10 @@ pub mod testing {
     }
 
     impl Distribution<TestNode> for Standard {
-        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> TestNode {
+        fn sample<R>(&self, rng: &mut R) -> TestNode
+        where
+            R: Rng + ?Sized,
+        {
             TestNode(rng.gen())
         }
     }
@@ -726,10 +756,14 @@ pub mod testing {
         any::<u64>().prop_map(TestNode)
     }
 
-    pub fn arb_frontier<H: Hashable + Clone + Debug, T: Strategy<Value = H>, const DEPTH: u8>(
+    pub fn arb_frontier<H, T, const DEPTH: u8>(
         min_size: usize,
         arb_node: T,
-    ) -> impl Strategy<Value = Frontier<H, DEPTH>> {
+    ) -> impl Strategy<Value = Frontier<H, DEPTH>>
+    where
+        H: Hashable + Clone + Debug,
+        T: Strategy<Value = H>,
+    {
         assert!((1 << DEPTH) >= min_size + 100);
         vec(arb_node, min_size..(min_size + 100)).prop_map(move |v| {
             let mut frontier = Frontier::empty();
@@ -745,14 +779,14 @@ pub mod testing {
 
     #[cfg(feature = "legacy-api")]
     #[cfg_attr(docsrs, doc(cfg(feature = "legacy-api")))]
-    pub fn arb_commitment_tree<
-        H: Hashable + Clone + Debug,
-        T: Strategy<Value = H>,
-        const DEPTH: u8,
-    >(
+    pub fn arb_commitment_tree<H, T, const DEPTH: u8>(
         min_size: usize,
         arb_node: T,
-    ) -> impl Strategy<Value = CommitmentTree<H, DEPTH>> {
+    ) -> impl Strategy<Value = CommitmentTree<H, DEPTH>>
+    where
+        H: Hashable + Clone + Debug,
+        T: Strategy<Value = H>,
+    {
         assert!((1 << DEPTH) >= min_size + 100);
         vec(arb_node, min_size..(min_size + 100)).prop_map(move |v| {
             let mut tree = CommitmentTree::empty();

--- a/incrementalmerkletree/src/lib.rs
+++ b/incrementalmerkletree/src/lib.rs
@@ -128,7 +128,10 @@ impl<C> Retention<C> {
     /// Applies the provided function to the checkpoint identifier, if any, and returns a new
     /// `Retention` value having the same structure with the resulting value used as the checkpoint
     /// identifier.
-    pub fn map<'a, D, F: Fn(&'a C) -> D>(&'a self, f: F) -> Retention<D> {
+    pub fn map<'a, D, F>(&'a self, f: F) -> Retention<D>
+    where
+        F: Fn(&'a C) -> D,
+    {
         match self {
             Retention::Ephemeral => Retention::Ephemeral,
             Retention::Checkpoint { id, marking } => Retention::Checkpoint {
@@ -639,7 +642,10 @@ impl<H, const DEPTH: u8> MerklePath<H, DEPTH> {
     }
 }
 
-impl<H: Hashable, const DEPTH: u8> MerklePath<H, DEPTH> {
+impl<H, const DEPTH: u8> MerklePath<H, DEPTH>
+where
+    H: Hashable,
+{
     /// Returns the root of the tree corresponding to this path applied to `leaf`.
     pub fn root(&self, leaf: H) -> H {
         self.path_elems

--- a/incrementalmerkletree/src/testing.rs
+++ b/incrementalmerkletree/src/testing.rs
@@ -24,7 +24,10 @@ impl Hashable for String {
     }
 }
 
-impl<H: Hashable> Hashable for Option<H> {
+impl<H> Hashable for Option<H>
+where
+    H: Hashable,
+{
     fn empty_leaf() -> Self {
         Some(H::empty_leaf())
     }

--- a/incrementalmerkletree/src/witness.rs
+++ b/incrementalmerkletree/src/witness.rs
@@ -177,7 +177,10 @@ impl<H, const DEPTH: u8> IncrementalWitness<H, DEPTH> {
     }
 }
 
-impl<H: Hashable + Clone, const DEPTH: u8> IncrementalWitness<H, DEPTH> {
+impl<H, const DEPTH: u8> IncrementalWitness<H, DEPTH>
+where
+    H: Hashable + Clone,
+{
     fn filler(&self) -> PathFiller<H> {
         let cursor_root = self
             .cursor

--- a/shardtree/src/batch.rs
+++ b/shardtree/src/batch.rs
@@ -39,11 +39,14 @@ impl<
     ///
     /// [`Node::Nil`]: crate::tree::Node::Nil
     #[allow(clippy::type_complexity)]
-    pub fn batch_insert<I: Iterator<Item = (H, Retention<C>)>>(
+    pub fn batch_insert<I>(
         &mut self,
         mut start: Position,
         values: I,
-    ) -> Result<Option<(Position, Vec<IncompleteAt>)>, ShardTreeError<S::Error>> {
+    ) -> Result<Option<(Position, Vec<IncompleteAt>)>, ShardTreeError<S::Error>>
+    where
+        I: Iterator<Item = (H, Retention<C>)>,
+    {
         trace!("Batch inserting from {:?}", start);
         let mut values = values.peekable();
         let mut subtree_root_addr = Self::subtree_addr(start);
@@ -90,7 +93,11 @@ impl<
 /// nodes within that tree that were introduced as a consequence of that insertion, and the
 /// remainder of the iterator that provided the inserted values.
 #[derive(Debug)]
-pub struct BatchInsertionResult<H, C: Ord, I: Iterator<Item = (H, Retention<C>)>> {
+pub struct BatchInsertionResult<H, C, I>
+where
+    C: Ord,
+    I: Iterator<Item = (H, Retention<C>)>,
+{
     /// The updated tree after all insertions have been performed.
     pub subtree: LocatedPrunableTree<H>,
     /// A flag identifying whether the constructed subtree contains a marked node.
@@ -110,16 +117,23 @@ pub struct BatchInsertionResult<H, C: Ord, I: Iterator<Item = (H, Retention<C>)>
     pub remainder: I,
 }
 
-impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
+impl<H> LocatedPrunableTree<H>
+where
+    H: Hashable + Clone + PartialEq,
+{
     /// Append a values from an iterator, beginning at the first available position in the tree.
     ///
     /// Returns an error if the tree is full. If the position at the end of the iterator is outside
     /// of the subtree's range, the unconsumed part of the iterator will be returned as part of
     /// the result.
-    pub fn batch_append<C: Clone + Ord, I: Iterator<Item = (H, Retention<C>)>>(
+    pub fn batch_append<C, I>(
         &self,
         values: I,
-    ) -> Result<Option<BatchInsertionResult<H, C, I>>, InsertionError> {
+    ) -> Result<Option<BatchInsertionResult<H, C, I>>, InsertionError>
+    where
+        C: Clone + Ord,
+        I: Iterator<Item = (H, Retention<C>)>,
+    {
         let append_position = self
             .max_position()
             .map(|p| p + 1)
@@ -137,11 +151,15 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
     /// Returns `Ok(None)` if the provided iterator is empty, `Ok(Some(BatchInsertionResult))` if
     /// values were successfully inserted, or an error if the start position provided is outside
     /// of this tree's position range or if a conflict with an existing subtree root is detected.
-    pub fn batch_insert<C: Clone + Ord, I: Iterator<Item = (H, Retention<C>)>>(
+    pub fn batch_insert<C, I>(
         &self,
         start: Position,
         values: I,
-    ) -> Result<Option<BatchInsertionResult<H, C, I>>, InsertionError> {
+    ) -> Result<Option<BatchInsertionResult<H, C, I>>, InsertionError>
+    where
+        C: Clone + Ord,
+        I: Iterator<Item = (H, Retention<C>)>,
+    {
         trace!("Batch inserting into {:?} from {:?}", self.root_addr, start);
         let subtree_range = self.root_addr.position_range();
         let contains_start = subtree_range.contains(&start);
@@ -182,11 +200,15 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
     ///   checkpointed node may be pruned so long as their address is at less than the specified
     ///   level.
     /// * `values` - The iterator of `(H, Retention)` pairs from which to construct the tree.
-    pub fn from_iter<C: Clone + Ord, I: Iterator<Item = (H, Retention<C>)>>(
+    pub fn from_iter<C, I>(
         position_range: Range<Position>,
         prune_below: Level,
         mut values: I,
-    ) -> Option<BatchInsertionResult<H, C, I>> {
+    ) -> Option<BatchInsertionResult<H, C, I>>
+    where
+        C: Clone + Ord,
+        I: Iterator<Item = (H, Retention<C>)>,
+    {
         trace!(
             position_range = ?position_range,
             prune_below = ?prune_below,
@@ -259,11 +281,14 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
 //
 // `unite` is only called when both root addrs have the same parent.  `batch_insert` never
 // constructs Nil nodes, so we don't create any incomplete root information here.
-fn unite<H: Hashable + Clone + PartialEq>(
+fn unite<H>(
     lroot: LocatedPrunableTree<H>,
     rroot: LocatedPrunableTree<H>,
     prune_below: Level,
-) -> LocatedPrunableTree<H> {
+) -> LocatedPrunableTree<H>
+where
+    H: Hashable + Clone + PartialEq,
+{
     assert_eq!(lroot.root_addr.parent(), rroot.root_addr.parent());
     LocatedTree {
         root_addr: lroot.root_addr.parent(),
@@ -280,13 +305,16 @@ fn unite<H: Hashable + Clone + PartialEq>(
 ///
 /// `expect_left_child` is set to a constant at each callsite, to ensure that this
 /// function is only called on either the left-most or right-most subtree.
-fn combine_with_empty<H: Hashable + Clone + PartialEq>(
+fn combine_with_empty<H>(
     root: LocatedPrunableTree<H>,
     expect_left_child: bool,
     incomplete: &mut Vec<IncompleteAt>,
     contains_marked: bool,
     prune_below: Level,
-) -> LocatedPrunableTree<H> {
+) -> LocatedPrunableTree<H>
+where
+    H: Hashable + Clone + PartialEq,
+{
     assert_eq!(expect_left_child, root.root_addr.is_left_child());
     let sibling_addr = root.root_addr.sibling();
     incomplete.push(IncompleteAt {
@@ -309,11 +337,14 @@ fn combine_with_empty<H: Hashable + Clone + PartialEq>(
 // and in position order. Returns the resulting tree, a flag indicating whether the
 // resulting tree contains a `MARKED` node, and the vector of [`IncompleteAt`] values for
 // [`Node::Nil`] nodes that were introduced in the process of constructing the tree.
-fn build_minimal_tree<H: Hashable + Clone + PartialEq>(
+fn build_minimal_tree<H>(
     mut xs: Vec<(LocatedPrunableTree<H>, bool)>,
     root_addr: Address,
     prune_below: Level,
-) -> Option<(LocatedPrunableTree<H>, bool, Vec<IncompleteAt>)> {
+) -> Option<(LocatedPrunableTree<H>, bool, Vec<IncompleteAt>)>
+where
+    H: Hashable + Clone + PartialEq,
+{
     // First, consume the stack from the right, building up a single tree
     // until we can't combine any more.
     if let Some((mut cur, mut contains_marked)) = xs.pop() {

--- a/shardtree/src/error.rs
+++ b/shardtree/src/error.rs
@@ -30,7 +30,10 @@ impl<S> From<InsertionError> for ShardTreeError<S> {
     }
 }
 
-impl<S: fmt::Display> fmt::Display for ShardTreeError<S> {
+impl<S> fmt::Display for ShardTreeError<S>
+where
+    S: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
             ShardTreeError::Query(q) => q.fmt(f),

--- a/shardtree/src/legacy.rs
+++ b/shardtree/src/legacy.rs
@@ -76,7 +76,10 @@ impl<
 }
 
 /// Operations on [`LocatedTree`]s that are annotated with Merkle hashes.
-impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
+impl<H> LocatedPrunableTree<H>
+where
+    H: Hashable + Clone + PartialEq,
+{
     fn combine_optional(
         opt_t0: Option<Self>,
         opt_t1: Option<Self>,

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -65,7 +65,10 @@ mod legacy;
 /// front of the tree, that are maintained such that it's possible to truncate nodes to the right
 /// of the specified position.
 #[derive(Debug)]
-pub struct ShardTree<S: ShardStore, const DEPTH: u8, const SHARD_HEIGHT: u8> {
+pub struct ShardTree<S, const DEPTH: u8, const SHARD_HEIGHT: u8>
+where
+    S: ShardStore,
+{
     /// The vector of tree shards.
     store: S,
     /// The maximum number of checkpoints to retain before pruning.
@@ -460,10 +463,10 @@ impl<
     /// Panics if `root` represents a parent node but `root_addr` is a depth-0 leaf address.
     pub fn checkpoint(&mut self, checkpoint_id: C) -> Result<bool, ShardTreeError<S::Error>> {
         /// Pre-condition: `root_addr` must be the address of `root`.
-        fn go<H: Hashable + Clone + PartialEq>(
-            root_addr: Address,
-            root: &PrunableTree<H>,
-        ) -> Option<(PrunableTree<H>, Position)> {
+        fn go<H>(root_addr: Address, root: &PrunableTree<H>) -> Option<(PrunableTree<H>, Position)>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
             match &root.0 {
                 Node::Parent { ann, left, right } => {
                     let (l_addr, r_addr) = root_addr
@@ -1784,14 +1787,17 @@ mod tests {
 
     // Combined tree tests
     #[allow(clippy::type_complexity)]
-    fn new_combined_tree<H: Hashable + Ord + Clone + core::fmt::Debug>(
+    fn new_combined_tree<H>(
         max_checkpoints: usize,
     ) -> CombinedTree<
         H,
         usize,
         CompleteTree<H, usize, 4>,
         ShardTree<MemoryShardStore<H, usize>, 4, 3>,
-    > {
+    >
+    where
+        H: Hashable + Ord + Clone + core::fmt::Debug,
+    {
         CombinedTree::new(
             CompleteTree::new(max_checkpoints),
             ShardTree::new(MemoryShardStore::empty(), max_checkpoints),

--- a/shardtree/src/prunable.rs
+++ b/shardtree/src/prunable.rs
@@ -110,7 +110,10 @@ impl fmt::Display for MergeError {
     }
 }
 
-impl<H: Hashable + Clone + PartialEq> PrunableTree<H> {
+impl<H> PrunableTree<H>
+where
+    H: Hashable + Clone + PartialEq,
+{
     /// Returns the the value if this is a leaf.
     pub fn leaf_value(&self) -> Option<&H> {
         self.0.leaf_value().map(|(h, _)| h)
@@ -277,11 +280,14 @@ impl<H: Hashable + Clone + PartialEq> PrunableTree<H> {
     pub fn merge_checked(self, root_addr: Address, other: Self) -> Result<Self, MergeError> {
         /// Pre-condition: `root_addr` must be the address of `t0` and `t1`.
         #[allow(clippy::type_complexity)]
-        fn go<H: Hashable + Clone + PartialEq>(
+        fn go<H>(
             addr: Address,
             t0: PrunableTree<H>,
             t1: PrunableTree<H>,
-        ) -> Result<PrunableTree<H>, MergeError> {
+        ) -> Result<PrunableTree<H>, MergeError>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
             // Require that any roots the we compute will not be default-filled by picking
             // a starting valid fill point that is outside the range of leaf positions.
             let no_default_fill = addr.position_range_end();
@@ -421,7 +427,10 @@ impl From<incrementalmerkletree::frontier::FrontierError> for FrontierError {
     }
 }
 
-impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
+impl<H> LocatedPrunableTree<H>
+where
+    H: Hashable + Clone + PartialEq,
+{
     /// Returns the maximum position at which a non-`Nil` leaf has been observed in the tree.
     ///
     /// Note that no actual leaf value may exist at this position, as it may have previously been
@@ -479,11 +488,10 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
     /// Returns the positions of marked leaves in the tree.
     pub fn marked_positions(&self) -> BTreeSet<Position> {
         /// Pre-condition: `root_addr` must be the address of `root`.
-        fn go<H: Hashable + Clone + PartialEq>(
-            root_addr: Address,
-            root: &PrunableTree<H>,
-            acc: &mut BTreeSet<Position>,
-        ) {
+        fn go<H>(root_addr: Address, root: &PrunableTree<H>, acc: &mut BTreeSet<Position>)
+        where
+            H: Hashable + Clone + PartialEq,
+        {
             match &root.0 {
                 Node::Parent { left, right, .. } => {
                     let (l_addr, r_addr) = root_addr
@@ -519,12 +527,15 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
         /// the authentication path on the way back up.
         //
         /// Pre-condition: `root_addr` must be the address of `root`.
-        fn go<H: Hashable + Clone + PartialEq>(
+        fn go<H>(
             root: &PrunableTree<H>,
             root_addr: Address,
             position: Position,
             truncate_at: Position,
-        ) -> Result<Vec<H>, Vec<Address>> {
+        ) -> Result<Vec<H>, Vec<Address>>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
             match &root.0 {
                 Node::Parent { left, right, .. } => {
                     let (l_addr, r_addr) = root_addr
@@ -605,11 +616,14 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
     /// otherwise.
     pub fn truncate_to_position(&self, position: Position) -> Option<Self> {
         /// Pre-condition: `root_addr` must be the address of `root`.
-        fn go<H: Hashable + Clone + PartialEq>(
+        fn go<H>(
             position: Position,
             root_addr: Address,
             root: &PrunableTree<H>,
-        ) -> Option<PrunableTree<H>> {
+        ) -> Option<PrunableTree<H>>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
             match &root.0 {
                 Node::Parent { ann, left, right } => {
                     let (l_child, r_child) = root_addr
@@ -673,12 +687,15 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
         ///
         /// Pre-condition: `root_addr` must be the address of `into`.
         #[allow(clippy::type_complexity)]
-        fn go<H: Hashable + Clone + PartialEq>(
+        fn go<H>(
             root_addr: Address,
             into: &PrunableTree<H>,
             subtree: LocatedPrunableTree<H>,
             contains_marked: bool,
-        ) -> Result<(PrunableTree<H>, Vec<IncompleteAt>), InsertionError> {
+        ) -> Result<(PrunableTree<H>, Vec<IncompleteAt>), InsertionError>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
             // An empty tree cannot replace any other type of tree.
             if subtree.root().is_nil() {
                 Ok((into.clone(), vec![]))
@@ -838,11 +855,14 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
     /// Prefer to use [`Self::batch_append`] or [`Self::batch_insert`] when appending multiple
     /// values, as these operations require fewer traversals of the tree than are necessary when
     /// performing multiple sequential calls to [`Self::append`].
-    pub fn append<C: Clone + Ord>(
+    pub fn append<C>(
         &self,
         value: H,
         retention: Retention<C>,
-    ) -> Result<(Self, Position, Option<C>), InsertionError> {
+    ) -> Result<(Self, Position, Option<C>), InsertionError>
+    where
+        C: Clone + Ord,
+    {
         let checkpoint_id = if let Retention::Checkpoint { id, .. } = &retention {
             Some(id.clone())
         } else {
@@ -979,11 +999,14 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
     /// that no longer need to be retained.
     pub fn clear_flags(&self, to_clear: BTreeMap<Position, RetentionFlags>) -> Self {
         /// Pre-condition: `root_addr` must be the address of `root`.
-        fn go<H: Hashable + Clone + PartialEq>(
+        fn go<H>(
             to_clear: &[(Position, RetentionFlags)],
             root_addr: Address,
             root: &PrunableTree<H>,
-        ) -> PrunableTree<H> {
+        ) -> PrunableTree<H>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
             if to_clear.is_empty() {
                 // nothing to do, so we just return the root
                 root.clone()
@@ -1073,10 +1096,13 @@ impl<H: Hashable + Clone + PartialEq> LocatedPrunableTree<H> {
         /// level, or `None` if the frontier cannot be extracted.
         ///
         /// Pre-condition: `addr` must be the address of `root`.
-        fn go<H: Hashable + Clone + PartialEq>(
+        fn go<H>(
             address: Address,
             root: &PrunableTree<H>,
-        ) -> Result<Option<(Position, H, Vec<H>)>, FrontierError> {
+        ) -> Result<Option<(Position, H, Vec<H>)>, FrontierError>
+        where
+            H: Hashable + Clone + PartialEq,
+        {
             match &root.0 {
                 Node::Nil => Err(FrontierError::TreeIncomplete { address }),
                 Node::Leaf { value: (h, _) } => {

--- a/shardtree/src/store.rs
+++ b/shardtree/src/store.rs
@@ -147,7 +147,10 @@ pub trait ShardStore {
     ) -> Result<(), Self::Error>;
 }
 
-impl<S: ShardStore> ShardStore for &mut S {
+impl<S> ShardStore for &mut S
+where
+    S: ShardStore,
+{
     type H = S::H;
     type CheckpointId = S::CheckpointId;
     type Error = S::Error;

--- a/shardtree/src/store/memory.rs
+++ b/shardtree/src/store/memory.rs
@@ -12,13 +12,19 @@ use crate::{LocatedPrunableTree, LocatedTree, PrunableTree, Tree};
 ///
 /// State is not persisted anywhere, and will be lost when the struct is dropped.
 #[derive(Debug)]
-pub struct MemoryShardStore<H, C: Ord> {
+pub struct MemoryShardStore<H, C>
+where
+    C: Ord,
+{
     shards: Vec<LocatedPrunableTree<H>>,
     checkpoints: BTreeMap<C, Checkpoint>,
     cap: PrunableTree<H>,
 }
 
-impl<H, C: Ord> MemoryShardStore<H, C> {
+impl<H, C> MemoryShardStore<H, C>
+where
+    C: Ord,
+{
     /// Constructs a new empty `MemoryShardStore`.
     pub fn empty() -> Self {
         Self {
@@ -29,7 +35,11 @@ impl<H, C: Ord> MemoryShardStore<H, C> {
     }
 }
 
-impl<H: Clone, C: Clone + Ord> ShardStore for MemoryShardStore<H, C> {
+impl<H, C> ShardStore for MemoryShardStore<H, C>
+where
+    H: Clone,
+    C: Clone + Ord,
+{
     type H = H;
     type CheckpointId = C;
     type Error = Infallible;

--- a/shardtree/src/testing.rs
+++ b/shardtree/src/testing.rs
@@ -19,13 +19,15 @@ pub fn arb_retention_flags() -> impl Strategy<Value = RetentionFlags> + Clone {
     ])
 }
 
-pub fn arb_tree<A: Strategy + Clone + 'static, V: Strategy + 'static>(
+pub fn arb_tree<A, V>(
     arb_annotation: A,
     arb_leaf: V,
     depth: u32,
     size: u32,
 ) -> impl Strategy<Value = Tree<A::Value, V::Value>> + Clone
 where
+    A: Strategy + Clone + 'static,
+    V: Strategy + 'static,
     A::Value: Clone + 'static,
     V::Value: Clone + 'static,
 {
@@ -42,12 +44,13 @@ where
     })
 }
 
-pub fn arb_prunable_tree<H: Strategy + Clone + 'static>(
+pub fn arb_prunable_tree<H>(
     arb_leaf: H,
     depth: u32,
     size: u32,
 ) -> impl Strategy<Value = PrunableTree<H::Value>> + Clone
 where
+    H: Strategy + Clone + 'static,
     H::Value: Clone + 'static,
 {
     arb_tree(
@@ -59,10 +62,9 @@ where
 }
 
 /// Constructs a random sequence of leaves that form a tree of size up to 2^6.
-pub fn arb_leaves<H: Strategy + Clone>(
-    arb_leaf: H,
-) -> impl Strategy<Value = Vec<(H::Value, Retention<usize>)>>
+pub fn arb_leaves<H>(arb_leaf: H) -> impl Strategy<Value = Vec<(H::Value, Retention<usize>)>>
 where
+    H: Strategy + Clone,
     H::Value: Hashable + Clone + PartialEq,
 {
     vec(
@@ -104,10 +106,9 @@ type ArbShardtreeParts<H> = (
 
 /// Constructs a random shardtree of size up to 2^6 with shards of size 2^3. Returns the tree,
 /// along with vectors of the checkpointed and marked positions.
-pub fn arb_shardtree<H: Strategy + Clone>(
-    arb_leaf: H,
-) -> impl Strategy<Value = ArbShardtreeParts<H>>
+pub fn arb_shardtree<H>(arb_leaf: H) -> impl Strategy<Value = ArbShardtreeParts<H>>
 where
+    H: Strategy + Clone,
     H::Value: Hashable + Clone + PartialEq,
 {
     arb_leaves(arb_leaf).prop_map(|leaves| {
@@ -344,9 +345,11 @@ pub fn check_shardtree_insertion<
     );
 }
 
-pub fn check_shard_sizes<E: Debug, S: ShardStore<H = String, CheckpointId = u32, Error = E>>(
-    mut tree: ShardTree<S, 4, 2>,
-) {
+pub fn check_shard_sizes<E, S>(mut tree: ShardTree<S, 4, 2>)
+where
+    E: Debug,
+    S: ShardStore<H = String, CheckpointId = u32, Error = E>,
+{
     for c in 'a'..'p' {
         tree.append(c.to_string(), Retention::Ephemeral).unwrap();
     }

--- a/shardtree/src/tree.rs
+++ b/shardtree/src/tree.rs
@@ -58,7 +58,12 @@ impl<C, A, V> Node<C, A, V> {
     }
 }
 
-impl<'a, C: Clone, A: Clone, V: Clone> Node<C, &'a A, &'a V> {
+impl<'a, C, A, V> Node<C, &'a A, &'a V>
+where
+    C: Clone,
+    A: Clone,
+    V: Clone,
+{
     /// Maps a `Node<C, &A, &V>` to a `Node<C, A, V>` by cloning the contents of the node.
     pub fn cloned(&self) -> Node<C, A, V> {
         match self {
@@ -155,8 +160,9 @@ impl<A, V> Tree<A, V> {
 
     /// Applies the provided function to each leaf of the tree and returns
     /// a new tree having the same structure as the original.
-    pub fn map<B, F: Fn(&V) -> B>(&self, f: &F) -> Tree<A, B>
+    pub fn map<B, F>(&self, f: &F) -> Tree<A, B>
     where
+        F: Fn(&V) -> B,
         A: Clone,
     {
         Tree(match &self.0 {
@@ -173,8 +179,9 @@ impl<A, V> Tree<A, V> {
     /// Applies the provided function to each leaf of the tree and returns
     /// a new tree having the same structure as the original, or an error
     /// if any transformation of the leaf fails.
-    pub fn try_map<B, E, F: Fn(&V) -> Result<B, E>>(&self, f: &F) -> Result<Tree<A, B>, E>
+    pub fn try_map<B, E, F>(&self, f: &F) -> Result<Tree<A, B>, E>
     where
+        F: Fn(&V) -> Result<B, E>,
         A: Clone,
     {
         Ok(Tree(match &self.0 {
@@ -289,8 +296,9 @@ impl<A, V> LocatedTree<A, V> {
 
     /// Applies the provided function to each leaf of the tree and returns
     /// a new tree having the same structure as the original.
-    pub fn map<B, F: Fn(&V) -> B>(&self, f: &F) -> LocatedTree<A, B>
+    pub fn map<B, F>(&self, f: &F) -> LocatedTree<A, B>
     where
+        F: Fn(&V) -> B,
         A: Clone,
     {
         LocatedTree {
@@ -302,8 +310,9 @@ impl<A, V> LocatedTree<A, V> {
     /// Applies the provided function to each leaf of the tree and returns
     /// a new tree having the same structure as the original, or an error
     /// if any transformation of the leaf fails.
-    pub fn try_map<B, E, F: Fn(&V) -> Result<B, E>>(&self, f: &F) -> Result<LocatedTree<A, B>, E>
+    pub fn try_map<B, E, F>(&self, f: &F) -> Result<LocatedTree<A, B>, E>
     where
+        F: Fn(&V) -> Result<B, E>,
         A: Clone,
     {
         Ok(LocatedTree {
@@ -313,7 +322,11 @@ impl<A, V> LocatedTree<A, V> {
     }
 }
 
-impl<A: Default + Clone, V: Clone> LocatedTree<A, V> {
+impl<A, V> LocatedTree<A, V>
+where
+    A: Default + Clone,
+    V: Clone,
+{
     /// Constructs a new empty tree with its root at the provided address.
     pub fn empty(root_addr: Address) -> Self {
         Self {
@@ -338,11 +351,15 @@ impl<A: Default + Clone, V: Clone> LocatedTree<A, V> {
     /// be reached.
     pub fn subtree(&self, addr: Address) -> Option<Self> {
         /// Pre-condition: `root_addr` must be the address of `root`.
-        fn go<A: Clone, V: Clone>(
+        fn go<A, V>(
             root_addr: Address,
             root: &Tree<A, V>,
             addr: Address,
-        ) -> Option<LocatedTree<A, V>> {
+        ) -> Option<LocatedTree<A, V>>
+        where
+            A: Clone,
+            V: Clone,
+        {
             if root_addr == addr {
                 Some(LocatedTree {
                     root_addr,
@@ -378,11 +395,11 @@ impl<A: Default + Clone, V: Clone> LocatedTree<A, V> {
     /// the entire tree is returned as the sole element of the result vector.
     pub fn decompose_to_level(self, level: Level) -> Vec<Self> {
         /// Pre-condition: `root_addr` must be the address of `root`.
-        fn go<A: Clone, V: Clone>(
-            level: Level,
-            root_addr: Address,
-            root: Tree<A, V>,
-        ) -> Vec<LocatedTree<A, V>> {
+        fn go<A, V>(level: Level, root_addr: Address, root: Tree<A, V>) -> Vec<LocatedTree<A, V>>
+        where
+            A: Clone,
+            V: Clone,
+        {
             if root_addr.level() == level {
                 vec![LocatedTree { root_addr, root }]
             } else {
@@ -435,7 +452,10 @@ pub(crate) mod tests {
         Tree::leaf(value)
     }
 
-    pub(crate) fn parent<A: Default, B>(left: Tree<A, B>, right: Tree<A, B>) -> Tree<A, B> {
+    pub(crate) fn parent<A, B>(left: Tree<A, B>, right: Tree<A, B>) -> Tree<A, B>
+    where
+        A: Default,
+    {
         Tree::parent(A::default(), left, right)
     }
 


### PR DESCRIPTION
This is a suggestion, and automated with a prompt to Claude I run on when exploring a new codebase. I noticed a discrepancy on the method of adding type constraints. This aims at unifying the approach.