### PR TITLE
shardtree: add regression test for get_shard_roots consumers

### DIFF
--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -2221,6 +2221,7 @@ mod tests {
     // are rooted at level 2 (4 leaves each); the cap spans levels 2..=4.
     // -----------------------------------------------------------------------
     mod root_internal {
+        use std::collections::BTreeSet;
         use std::sync::Arc;
 
         use assert_matches::assert_matches;
@@ -2292,6 +2293,34 @@ mod tests {
             tree
         }
 
+        // A complete shard at level 2 (root address `(2, index)`) holding the
+        // four given leaves, with the leaves at the listed slot indices (`0..4`)
+        // carrying the `MARKED` retention flag instead of `EPHEMERAL`. The leaf
+        // in slot `s` is at absolute position `index * 4 + s`. Used to exercise
+        // consumers of `get_shard_roots` that care about per-leaf retention.
+        fn shard_with_marks(
+            index: u64,
+            leaves: [&str; 4],
+            marked_slots: &[usize],
+        ) -> LocatedPrunableTree<String> {
+            let leaf = |slot: usize| {
+                let flags = if marked_slots.contains(&slot) {
+                    RetentionFlags::MARKED
+                } else {
+                    RetentionFlags::EPHEMERAL
+                };
+                Tree::leaf((leaves[slot].to_string(), flags))
+            };
+            LocatedTree {
+                root_addr: addr(2, index),
+                root: pparent(
+                    None,
+                    pparent(None, leaf(0), leaf(1)),
+                    pparent(None, leaf(2), leaf(3)),
+                ),
+            }
+        }
+
         #[test]
         fn non_contiguous_shards_are_sparse_and_root_correctly() {
             // Shards 2 and 3 are present; shards 0 and 1 are absent (a gap below the
@@ -2329,6 +2358,44 @@ mod tests {
                 tree.root(addr(3, 0), Position::from(8)),
                 Err(ShardTreeError::Query(QueryError::TreeIncomplete(_))),
             ));
+        }
+
+        #[test]
+        fn marked_positions_consumer_tolerates_sparse_shard_roots() {
+            // Regression test for the consumers of `ShardStore::get_shard_roots`.
+            //
+            // `ShardTree::marked_positions` iterates the shard roots reported by
+            // the store, fetches each shard, and unions their marked positions.
+            // With the sparse `MemoryShardStore`, `get_shard_roots` reports only
+            // the populated shards (no back-filled empties), so the consumer
+            // must:
+            //   - report the marks from every populated shard, and
+            //   - never fabricate positions for the absent gap below the
+            //     populated range (and never panic walking it).
+            //
+            // Shards 2 and 3 are populated (positions 8..16); shards 0 and 1
+            // (the gap, positions 0..8) are absent.
+            let tree = tree_with_shards(&[
+                // shard 2 (positions 8..12): mark position 10 (slot 2).
+                shard_with_marks(2, ["i", "j", "k", "l"], &[2]),
+                // shard 3 (positions 12..16): mark positions 13 and 15
+                // (slots 1 and 3).
+                shard_with_marks(3, ["m", "n", "o", "p"], &[1, 3]),
+            ]);
+
+            // The store reports only the two populated shard roots ...
+            assert_eq!(
+                tree.store.get_shard_roots().unwrap(),
+                vec![addr(2, 2), addr(2, 3)],
+            );
+
+            // ... and `marked_positions` reports exactly the marks from those
+            // shards, with no phantom positions contributed by the absent
+            // `0..8` gap.
+            assert_eq!(
+                tree.marked_positions().unwrap(),
+                BTreeSet::from([Position::from(10), Position::from(13), Position::from(15),]),
+            );
         }
 
         // ---- Phase 1: fast path (cached value returned immediately) ---------

--- a/shardtree/src/store/caching.rs
+++ b/shardtree/src/store/caching.rs
@@ -271,6 +271,68 @@ mod tests {
     }
 
     #[test]
+    fn load_flush_roundtrip_preserves_sparse_shards() {
+        use incrementalmerkletree::{Address, Level};
+
+        use crate::{LocatedPrunableTree, LocatedTree, RetentionFlags, Tree};
+
+        // Regression test for the consumers of `get_shard_roots` in
+        // `CachingShardStore::{load, flush}`. Both iterate `get_shard_roots`
+        // and resolve each reported root via `get_shard(...).expect("known
+        // address")`, so they rely on `get_shard_roots` and `get_shard` staying
+        // consistent. When `MemoryShardStore` started storing shards sparsely,
+        // `get_shard_roots` stopped reporting the back-filled empty placeholder
+        // shards below the first populated index; this exercises a sparse
+        // backend (a gap below the populated range, as for a wallet synced from
+        // a recent birthday) end to end through load and flush, asserting the
+        // exact sparse set round-trips with no panic and no materialized gap.
+
+        // A minimal shard rooted at the shard level (3) and the given index.
+        // The store keys shards by index and does not inspect their shape, so a
+        // single-leaf root is sufficient for this storage-layer round trip.
+        fn shard(index: u64) -> LocatedPrunableTree<String> {
+            LocatedTree {
+                root_addr: Address::from_parts(Level::from(3), index),
+                root: Tree::leaf((format!("shard{index}"), RetentionFlags::EPHEMERAL)),
+            }
+        }
+
+        // Indices 2 and 3 are populated; 0 and 1 are absent.
+        let mut backend = MemoryShardStore::<String, u64>::empty();
+        backend.put_shard(shard(2)).unwrap();
+        backend.put_shard(shard(3)).unwrap();
+
+        let expected_roots = vec![
+            Address::from_parts(Level::from(3), 2),
+            Address::from_parts(Level::from(3), 3),
+        ];
+        assert_eq!(backend.get_shard_roots().unwrap(), expected_roots);
+
+        // `load` copies the sparse shards into the cache: every root reported by
+        // the backend resolves to a present shard (no panic on the
+        // `.expect("known address")`), and the gap is not back-filled.
+        let caching = CachingShardStore::load(backend).unwrap();
+        assert_eq!(caching.get_shard_roots().unwrap(), expected_roots);
+
+        // `flush` writes the cache back to the backend, round-tripping exactly
+        // the sparse set.
+        let restored = caching.flush().unwrap();
+        assert_eq!(restored.get_shard_roots().unwrap(), expected_roots);
+        for root in &expected_roots {
+            assert!(restored.get_shard(*root).unwrap().is_some());
+        }
+        // The gap below the populated range stays absent after the round trip.
+        assert!(restored
+            .get_shard(Address::from_parts(Level::from(3), 0))
+            .unwrap()
+            .is_none());
+        assert!(restored
+            .get_shard(Address::from_parts(Level::from(3), 1))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
     fn root_hashes() {
         use Retention::*;
 


### PR DESCRIPTION
PR #174 made MemoryShardStore store shards sparsely in a BTreeMap, so get_shard_roots no longer reports back-filled empty placeholder shards below the first populated index. Its only consumer, marked_positions, must keep reporting every mark from populated shards and must not fabricate positions for the absent gap.

Add marked_positions_consumer_tolerates_sparse_shard_roots, which populates non-contiguous shards with marks above an absent gap and asserts both that get_shard_roots stays sparse and that marked_positions returns exactly the marks from the populated shards.