### PR TITLE
Revert "shardtree: store MemoryShardStore shards sparsely in a BTreeMap"

### DIFF
--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -14,16 +14,6 @@ and this project adheres to Rust's notion of
 - `shardtree::LocatedPrunableTree::pretty_print_indented`
 - `shardtree::LocatedPrunableTree::pretty_print_bottom_top`
 
-### Changed
-- `shardtree::store::memory::MemoryShardStore` now stores shards sparsely in a
-  `BTreeMap` keyed by shard index, rather than a dense `Vec`. Observable
-  behaviour through the `ShardStore` interface is unchanged, except that a shard
-  index that has never been inserted now reads back from `get_shard` as `None`
-  rather than as a materialized empty shard (matching the persistent backends),
-  and `get_shard_roots` returns only populated indices. This avoids allocating
-  the run of empty shards below a high starting shard index — e.g. for a wallet
-  synced from a recent birthday, whose first populated shard index is large.
-
 ## [0.6.2] - 2026-02-20
 
 ### Added

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -2292,45 +2292,6 @@ mod tests {
             tree
         }
 
-        #[test]
-        fn non_contiguous_shards_are_sparse_and_root_correctly() {
-            // Shards 2 and 3 are present; shards 0 and 1 are absent (a gap below the
-            // populated range — e.g. a wallet synced from a recent birthday). The
-            // `MemoryShardStore` must NOT back-fill empty shards for the gap, and the
-            // cap/frontier logic must tolerate non-contiguous shard roots.
-            let tree =
-                tree_with_shards(&[shard(2, "i", "j", "k", "l"), shard(3, "m", "n", "o", "p")]);
-
-            // The store is sparse: only the two populated shard roots, NOT a
-            // back-filled contiguous `0..=3`.
-            assert_eq!(
-                tree.store.get_shard_roots().unwrap(),
-                vec![addr(2, 2), addr(2, 3)],
-            );
-            // A gap index reads back as absent (`None`), never as an empty shard.
-            assert!(tree.store.get_shard(addr(2, 0)).unwrap().is_none());
-            assert!(tree.store.get_shard(addr(2, 1)).unwrap().is_none());
-            // `last_shard` is the highest populated shard.
-            assert_eq!(
-                tree.store.last_shard().unwrap().map(|s| s.root_addr),
-                Some(addr(2, 3)),
-            );
-
-            // The cap/frontier logic folds the two non-contiguous present shards into
-            // the `(3, 1)` subtree root, exactly as a dense store would.
-            assert_eq!(
-                tree.root(addr(3, 1), Position::from(16)).unwrap(),
-                "ijklmnop".to_string(),
-            );
-
-            // A root that spans the gap reports the tree as incomplete (it does not
-            // panic, and does not fabricate a value from absent shards).
-            assert!(matches!(
-                tree.root(addr(3, 0), Position::from(8)),
-                Err(ShardTreeError::Query(QueryError::TreeIncomplete(_))),
-            ));
-        }
-
         // ---- Phase 1: fast path (cached value returned immediately) ---------
 
         #[test]

--- a/shardtree/src/store/memory.rs
+++ b/shardtree/src/store/memory.rs
@@ -1,26 +1,19 @@
 //! Implementation of an in-memory shard store with no persistence.
 
 use std::collections::BTreeMap;
-use std::convert::Infallible;
+use std::convert::{Infallible, TryFrom};
 
 use incrementalmerkletree::Address;
 
 use super::{Checkpoint, ShardStore};
-use crate::{LocatedPrunableTree, PrunableTree};
+use crate::{LocatedPrunableTree, LocatedTree, PrunableTree, Tree};
 
 /// An implementation of [`ShardStore`] that stores all state in memory.
 ///
 /// State is not persisted anywhere, and will be lost when the struct is dropped.
-///
-/// Shards are stored sparsely in a [`BTreeMap`] keyed by shard index: only shards explicitly
-/// inserted via [`ShardStore::put_shard`] are retained, and an index with no inserted shard reads
-/// back as `None` (never as an empty shard). This matches the behaviour of persistent backends such
-/// as the SQLite-backed store, and avoids materializing the run of empty shards below a high
-/// starting index — e.g. for a wallet synced from a recent birthday, whose first populated shard
-/// index is large.
 #[derive(Debug)]
 pub struct MemoryShardStore<H, C: Ord> {
-    shards: BTreeMap<u64, LocatedPrunableTree<H>>,
+    shards: Vec<LocatedPrunableTree<H>>,
     checkpoints: BTreeMap<C, Checkpoint>,
     cap: PrunableTree<H>,
 }
@@ -29,7 +22,7 @@ impl<H, C: Ord> MemoryShardStore<H, C> {
     /// Constructs a new empty `MemoryShardStore`.
     pub fn empty() -> Self {
         Self {
-            shards: BTreeMap::new(),
+            shards: vec![],
             checkpoints: BTreeMap::new(),
             cap: PrunableTree::empty(),
         }
@@ -45,25 +38,39 @@ impl<H: Clone, C: Clone + Ord> ShardStore for MemoryShardStore<H, C> {
         &self,
         shard_root: Address,
     ) -> Result<Option<LocatedPrunableTree<H>>, Self::Error> {
-        Ok(self.shards.get(&shard_root.index()).cloned())
+        let shard_idx =
+            usize::try_from(shard_root.index()).expect("SHARD_HEIGHT > 64 is unsupported");
+        Ok(self.shards.get(shard_idx).cloned())
     }
 
     fn last_shard(&self) -> Result<Option<LocatedPrunableTree<H>>, Self::Error> {
-        Ok(self.shards.values().next_back().cloned())
+        Ok(self.shards.last().cloned())
     }
 
     fn put_shard(&mut self, subtree: LocatedPrunableTree<H>) -> Result<(), Self::Error> {
-        self.shards.insert(subtree.root_addr.index(), subtree);
+        let subtree_addr = subtree.root_addr;
+        for subtree_idx in
+            self.shards.last().map_or(0, |s| s.root_addr.index() + 1)..=subtree_addr.index()
+        {
+            self.shards.push(LocatedTree {
+                root_addr: Address::from_parts(subtree_addr.level(), subtree_idx),
+                root: Tree::empty(),
+            })
+        }
+
+        let shard_idx =
+            usize::try_from(subtree_addr.index()).expect("SHARD_HEIGHT > 64 is unsupported");
+        self.shards[shard_idx] = subtree;
         Ok(())
     }
 
     fn get_shard_roots(&self) -> Result<Vec<Address>, Self::Error> {
-        Ok(self.shards.values().map(|s| s.root_addr).collect())
+        Ok(self.shards.iter().map(|s| s.root_addr).collect())
     }
 
     fn truncate_shards(&mut self, shard_index: u64) -> Result<(), Self::Error> {
-        // Drop every shard with index >= `shard_index`.
-        self.shards.split_off(&shard_index);
+        let shard_idx = usize::try_from(shard_index).expect("SHARD_HEIGHT > 64 is unsupported");
+        self.shards.truncate(shard_idx);
         Ok(())
     }
 


### PR DESCRIPTION
This reverts commit 0099c4b1729968083953ab988be2385c0c242510.

See https://github.com/zcash/incrementalmerkletree/pull/178. !178 fails on current main.
See comment https://github.com/zcash/incrementalmerkletree/pull/174/changes#r3468042303