### PR TITLE
shardtree: generalize proptest strategies and add arb_shard_layout

### DIFF
--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -2035,6 +2035,24 @@ mod tests {
             }
             prop_assert_eq!(tree.marked_positions().unwrap(), layout.marked_positions);
         }
+
+        // Regression test: the dense MemoryShardStore back-fills empty
+        // placeholder shards, so get_shard_roots reports a contiguous
+        // 0..=max_populated_index range of roots.
+        #[test]
+        fn get_shard_roots_is_dense_up_to_max_index(
+            layout in arb_shard_layout(arb_char_str(), 2, 8, 4)
+        ) {
+            let mut tree = empty_tree::<String, 4, 2>();
+            for shard in &layout.shards {
+                tree.store.put_shard(shard.clone()).unwrap();
+            }
+            let max_index = layout.shards.iter().map(|s| s.root_addr.index()).max().unwrap();
+            let expected: Vec<Address> = (0..=max_index)
+                .map(|i| Address::from_parts(Level::from(2), i))
+                .collect();
+            prop_assert_eq!(tree.store.get_shard_roots().unwrap(), expected);
+        }
     }
 
     #[test]

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -1549,8 +1549,8 @@ mod tests {
         error::{QueryError, ShardTreeError},
         store::{memory::MemoryShardStore, ShardStore},
         testing::{
-            arb_char_str, arb_shardtree, check_shard_sizes, check_shardtree_insertion,
-            check_witness_with_pruned_subtrees,
+            arb_char_str, arb_shard_layout, arb_shardtree_sized, check_shard_sizes,
+            check_shardtree_insertion, check_witness_with_pruned_subtrees,
         },
         InsertionError, LocatedPrunableTree, LocatedTree, ShardTree,
     };
@@ -1981,31 +1981,59 @@ mod tests {
         }
     }
 
+    fn check_caching<const DEPTH: u8, const SHARD_HEIGHT: u8>(
+        mut tree: ShardTree<MemoryShardStore<String, usize>, DEPTH, SHARD_HEIGHT>,
+        marked_positions: Vec<Position>,
+    ) {
+        if let Some(max_leaf_pos) = tree.max_leaf_position(None).unwrap() {
+            let max_complete_addr =
+                Address::above_position(max_leaf_pos.root_level(), max_leaf_pos);
+            let root = tree.root(max_complete_addr, max_leaf_pos + 1);
+            let caching_root = tree.root_caching(max_complete_addr, max_leaf_pos + 1);
+            assert_matches!(root, Ok(_));
+            assert_eq!(root, caching_root);
+        }
+
+        if let Ok(Some(checkpoint_position)) = tree.max_leaf_position(Some(0)) {
+            for pos in marked_positions {
+                let witness = tree.witness_at_checkpoint_depth(pos, 0);
+                let caching_witness = tree.witness_at_checkpoint_depth_caching(pos, 0);
+                if pos <= checkpoint_position {
+                    assert_matches!(witness, Ok(_));
+                }
+                assert_eq!(witness, caching_witness);
+            }
+        }
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
 
         #[test]
         fn check_shardtree_caching(
-            (mut tree, _, marked_positions) in arb_shardtree(arb_char_str())
+            (tree, _, marked_positions) in arb_shardtree_sized::<_, 6, 3>(arb_char_str())
         ) {
-            if let Some(max_leaf_pos) = tree.max_leaf_position(None).unwrap() {
-                let max_complete_addr = Address::above_position(max_leaf_pos.root_level(), max_leaf_pos);
-                let root = tree.root(max_complete_addr, max_leaf_pos + 1);
-                let caching_root = tree.root_caching(max_complete_addr, max_leaf_pos + 1);
-                assert_matches!(root, Ok(_));
-                assert_eq!(root, caching_root);
-            }
+            check_caching(tree, marked_positions);
+        }
 
-            if let Ok(Some(checkpoint_position)) = tree.max_leaf_position(Some(0)) {
-                for pos in marked_positions {
-                    let witness = tree.witness_at_checkpoint_depth(pos, 0);
-                    let caching_witness = tree.witness_at_checkpoint_depth_caching(pos, 0);
-                    if pos <= checkpoint_position {
-                        assert_matches!(witness, Ok(_));
-                    }
-                    assert_eq!(witness, caching_witness);
-                }
+        #[test]
+        fn check_shardtree_caching_small_shards(
+            (tree, _, marked_positions) in arb_shardtree_sized::<_, 4, 2>(arb_char_str())
+        ) {
+            check_caching(tree, marked_positions);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn marked_positions_matches_shard_layout(
+            layout in arb_shard_layout(arb_char_str(), 2, 8, 4)
+        ) {
+            let mut tree = empty_tree::<String, 4, 2>();
+            for shard in &layout.shards {
+                tree.store.put_shard(shard.clone()).unwrap();
             }
+            prop_assert_eq!(tree.marked_positions().unwrap(), layout.marked_positions);
         }
     }
 

--- a/shardtree/src/testing.rs
+++ b/shardtree/src/testing.rs
@@ -42,12 +42,13 @@ where
     })
 }
 
-pub fn arb_prunable_tree<H: Strategy + Clone + 'static>(
+pub fn arb_prunable_tree<H>(
     arb_leaf: H,
     depth: u32,
     size: u32,
 ) -> impl Strategy<Value = PrunableTree<H::Value>> + Clone
 where
+    H: Strategy + Clone + 'static,
     H::Value: Clone + 'static,
 {
     arb_tree(
@@ -58,18 +59,17 @@ where
     )
 }
 
-/// Constructs a random sequence of leaves that form a tree of size up to 2^6.
-pub fn arb_leaves<H: Strategy + Clone>(
+/// Constructs a random sequence of up to `max_count` leaves, each randomly
+/// assigned ephemeral, checkpoint, or marked retention.
+pub fn arb_leaves_sized<H>(
     arb_leaf: H,
+    max_count: usize,
 ) -> impl Strategy<Value = Vec<(H::Value, Retention<usize>)>>
 where
+    H: Strategy + Clone,
     H::Value: Hashable + Clone + PartialEq,
 {
-    vec(
-        (arb_leaf, weighted(0.1), weighted(0.2)),
-        0..=(2usize.pow(6)),
-    )
-    .prop_map(|leaves| {
+    vec((arb_leaf, weighted(0.1), weighted(0.2)), 0..=max_count).prop_map(|leaves| {
         leaves
             .into_iter()
             .enumerate()
@@ -94,6 +94,15 @@ where
     })
 }
 
+/// Constructs a random sequence of leaves that form a tree of size up to 2^6.
+pub fn arb_leaves<H>(arb_leaf: H) -> impl Strategy<Value = Vec<(H::Value, Retention<usize>)>>
+where
+    H: Strategy + Clone,
+    H::Value: Hashable + Clone + PartialEq,
+{
+    arb_leaves_sized(arb_leaf, 2usize.pow(6))
+}
+
 /// A random shardtree of size up to 2^6 with shards of size 2^3, along with vectors of the
 /// checkpointed and marked positions within the tree.
 type ArbShardtreeParts<H> = (
@@ -102,15 +111,23 @@ type ArbShardtreeParts<H> = (
     Vec<Position>,
 );
 
-/// Constructs a random shardtree of size up to 2^6 with shards of size 2^3. Returns the tree,
-/// along with vectors of the checkpointed and marked positions.
-pub fn arb_shardtree<H: Strategy + Clone>(
+/// Constructs a random shardtree of `DEPTH` and `SHARD_HEIGHT`, of size up to
+/// 2^`DEPTH`. Returns the tree, along with vectors of the checkpointed and
+/// marked positions.
+pub fn arb_shardtree_sized<H, const DEPTH: u8, const SHARD_HEIGHT: u8>(
     arb_leaf: H,
-) -> impl Strategy<Value = ArbShardtreeParts<H>>
+) -> impl Strategy<
+    Value = (
+        ShardTree<MemoryShardStore<H::Value, usize>, DEPTH, SHARD_HEIGHT>,
+        Vec<Position>,
+        Vec<Position>,
+    ),
+>
 where
+    H: Strategy + Clone,
     H::Value: Hashable + Clone + PartialEq,
 {
-    arb_leaves(arb_leaf).prop_map(|leaves| {
+    arb_leaves_sized(arb_leaf, 1usize << DEPTH).prop_map(|leaves| {
         let mut tree = ShardTree::new(MemoryShardStore::empty(), 10);
         let mut checkpoint_positions = vec![];
         let mut marked_positions = vec![];
@@ -139,9 +156,82 @@ where
     })
 }
 
+/// Constructs a random shardtree of size up to 2^6 with shards of size 2^3. Returns the tree,
+/// along with vectors of the checkpointed and marked positions.
+pub fn arb_shardtree<H>(arb_leaf: H) -> impl Strategy<Value = ArbShardtreeParts<H>>
+where
+    H: Strategy + Clone,
+    H::Value: Hashable + Clone + PartialEq,
+{
+    arb_shardtree_sized::<H, 6, 3>(arb_leaf)
+}
+
 pub fn arb_char_str() -> impl Strategy<Value = String> + Clone {
     let chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     (0usize..chars.len()).prop_map(move |i| chars.get(i..=i).unwrap().to_string())
+}
+
+/// A randomly generated collection of complete shards placed at arbitrary,
+/// possibly non-contiguous indices, paired with the marked positions they hold.
+#[derive(Clone, Debug)]
+pub struct ShardLayout<H> {
+    pub shards: Vec<LocatedPrunableTree<H>>,
+    pub marked_positions: BTreeSet<Position>,
+}
+
+/// Builds the perfect binary tree over `leaves`, whose length must be a power of
+/// two, as an unannotated `PrunableTree`.
+fn perfect_shard<H: Clone>(leaves: &[(H, RetentionFlags)]) -> PrunableTree<H> {
+    if let [(value, flags)] = leaves {
+        Tree::leaf((value.clone(), *flags))
+    } else {
+        let mid = leaves.len() / 2;
+        Tree::parent(
+            None,
+            perfect_shard(&leaves[..mid]),
+            perfect_shard(&leaves[mid..]),
+        )
+    }
+}
+
+/// Strategy for a [`ShardLayout`]: between 1 and `max_shards` complete shards of
+/// height `shard_height`, at distinct indices drawn from `0..max_index`, each
+/// leaf carrying a random retention flag. `max_index` must be at least
+/// `max_shards` so that enough distinct indices exist.
+pub fn arb_shard_layout<H>(
+    arb_leaf: H,
+    shard_height: u8,
+    max_index: u64,
+    max_shards: usize,
+) -> impl Strategy<Value = ShardLayout<H::Value>>
+where
+    H: Strategy + Clone + 'static,
+    H::Value: Clone + core::fmt::Debug + 'static,
+{
+    let leaf_count = 1usize << shard_height;
+    let shard_contents = vec((arb_leaf, arb_retention_flags()), leaf_count);
+    proptest::collection::btree_map(0u64..max_index, shard_contents, 1..=max_shards).prop_map(
+        move |layout| {
+            let mut shards = Vec::with_capacity(layout.len());
+            let mut marked_positions = BTreeSet::new();
+            for (index, leaves) in layout {
+                let base = index << shard_height;
+                for (slot, (_, flags)) in leaves.iter().enumerate() {
+                    if flags.is_marked() {
+                        marked_positions.insert(Position::from(base + slot as u64));
+                    }
+                }
+                shards.push(LocatedTree {
+                    root_addr: Address::from_parts(Level::from(shard_height), index),
+                    root: perfect_shard(&leaves),
+                });
+            }
+            ShardLayout {
+                shards,
+                marked_positions,
+            }
+        },
+    )
 }
 
 impl<


### PR DESCRIPTION
Add size-parametric proptest strategies so property tests are no longer locked to a single tree geometry, and a strategy for arbitrary shard layouts that replaces hand-rolled fixtures.

- arb_leaves_sized(arb_leaf, max_count): arb_leaves now delegates to it with the previous 2^6 bound.
- arb_shardtree_sized::<H, DEPTH, SHARD_HEIGHT>: const-generic over the tree dimensions; arb_shardtree delegates to the 6,3 instantiation.
- arb_shard_layout(arb_leaf, shard_height, max_index, max_shards): generates complete shards at distinct, possibly non-contiguous indices with random per-leaf retention, paired with the marked positions they contain as an oracle.

Rewrite check_shardtree_caching onto arb_shardtree_sized via a geometry-generic check_caching helper, and exercise it at a second 4,2 geometry. Add marked_positions_matches_shard_layout to cover arb_shard_layout against ShardTree::marked_positions.


Also add a regtest, as initially it was for https://github.com/zcash/incrementalmerkletree/pull/178.