### PR TITLE
shardtree: explicit retention of checkpoints (durable anchors)

### DIFF
--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to Rust's notion of
 - `shardtree::LocatedTree::pretty_print_bottom_top_with`
 - `shardtree::LocatedPrunableTree::pretty_print_indented`
 - `shardtree::LocatedPrunableTree::pretty_print_bottom_top`
+- `shardtree::ShardTree::ensure_retained`
+- `shardtree::ShardTree::remove_retained_checkpoint`
+- `shardtree::store::ShardStore::add_retained_checkpoint`
+- `shardtree::store::ShardStore::remove_retained_checkpoint`
+- `shardtree::store::ShardStore::retained_checkpoints`
+
+### Changed
+- A checkpoint that has been explicitly retained via
+  `ShardTree::ensure_retained` is treated as a durable "anchor":
+  `ShardTree::prune_excess_checkpoints` excludes retained checkpoints from the
+  `max_checkpoints` budget and never removes them, so their root and the
+  witnesses for marked leaves at or before them remain computable even after
+  they have aged more than `max_checkpoints` behind the tip of the tree.
+  Retention is released with `ShardTree::remove_retained_checkpoint`.
 
 ## [0.6.2] - 2026-02-20
 

--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.7.0] - PLANNED
 
 ### Added
 - `impl Display for shardtree::RetentionFlags`
@@ -15,9 +15,6 @@ and this project adheres to Rust's notion of
 - `shardtree::LocatedPrunableTree::pretty_print_bottom_top`
 - `shardtree::ShardTree::ensure_retained`
 - `shardtree::ShardTree::remove_retained_checkpoint`
-- `shardtree::store::ShardStore::add_retained_checkpoint`
-- `shardtree::store::ShardStore::remove_retained_checkpoint`
-- `shardtree::store::ShardStore::retained_checkpoints`
 
 ### Changed
 - A checkpoint that has been explicitly retained via
@@ -27,6 +24,11 @@ and this project adheres to Rust's notion of
   witnesses for marked leaves at or before them remain computable even after
   they have aged more than `max_checkpoints` behind the tip of the tree.
   Retention is released with `ShardTree::remove_retained_checkpoint`.
+- The `shardtree::store::ShardStore` trait has been modified. It has added methods:
+  - `ShardStore::add_retained_checkpoint`
+  - `ShardStore::remove_retained_checkpoint`
+  - `ShardStore::retained_checkpoints`
+
 
 ## [0.6.2] - 2026-02-20
 

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -577,6 +577,32 @@ impl<
         Ok(true)
     }
 
+    /// Marks the checkpoint having the given identifier for retention, exempting it from automatic
+    /// pruning of excess checkpoints.
+    ///
+    /// A retained checkpoint is excluded from the `max_checkpoints` budget and is never removed by
+    /// [`Self::prune_excess_checkpoints`]; it persists until it is released via
+    /// [`Self::remove_retained_checkpoint`]. As a result, its root, and witnesses for marked leaves
+    /// at or before it, remain computable even after it has aged more than `max_checkpoints` behind
+    /// the tip of the tree. The identifier may be recorded even if no checkpoint with that
+    /// identifier currently exists.
+    pub fn ensure_retained(&mut self, checkpoint_id: C) -> Result<(), ShardTreeError<S::Error>> {
+        self.store
+            .add_retained_checkpoint(checkpoint_id)
+            .map_err(ShardTreeError::Storage)
+    }
+
+    /// Releases a checkpoint previously retained via [`Self::ensure_retained`], allowing it to be
+    /// pruned normally. Has no effect if the checkpoint was not retained.
+    pub fn remove_retained_checkpoint(
+        &mut self,
+        checkpoint_id: &C,
+    ) -> Result<(), ShardTreeError<S::Error>> {
+        self.store
+            .remove_retained_checkpoint(checkpoint_id)
+            .map_err(ShardTreeError::Storage)
+    }
+
     /// Removes the oldest checkpoints until at most `max_checkpoints` remain,
     /// clearing the `CHECKPOINT` and `MARKED` retention flags they were keeping
     /// alive so the affected leaves become prunable.
@@ -590,15 +616,35 @@ impl<
             .store
             .checkpoint_count()
             .map_err(ShardTreeError::Storage)?;
+
+        // Checkpoints in the explicit retention set are pinned: they are excluded from the
+        // `max_checkpoints` budget and are never removed by automatic pruning. The budget therefore
+        // applies only to the non-retained checkpoints.
+        let retained = self
+            .store
+            .retained_checkpoints()
+            .map_err(ShardTreeError::Storage)?;
+        let mut retained_existing = 0usize;
+        self.store
+            .for_each_checkpoint(checkpoint_count, |cid, _| {
+                if retained.contains(cid) {
+                    retained_existing += 1;
+                }
+                Ok(())
+            })
+            .map_err(ShardTreeError::Storage)?;
+        let prunable_count = checkpoint_count - retained_existing;
+
         trace!(
-            "Tree has {} checkpoints, max is {}",
+            "Tree has {} checkpoints ({} retained), max is {}",
             checkpoint_count,
+            retained_existing,
             self.max_checkpoints,
         );
-        if checkpoint_count > self.max_checkpoints {
+        if prunable_count > self.max_checkpoints {
             // Batch removals by subtree & create a list of the checkpoint identifiers that
             // will be removed from the checkpoints map.
-            let remove_count = checkpoint_count - self.max_checkpoints;
+            let remove_count = prunable_count - self.max_checkpoints;
             let mut checkpoints_to_delete = vec![];
             let mut clear_positions: BTreeMap<Address, BTreeMap<Position, RetentionFlags>> =
                 BTreeMap::new();
@@ -607,8 +653,9 @@ impl<
                     // When removing is true, we are iterating through the range of
                     // checkpoints being removed. When remove is false, we are
                     // iterating through the range of checkpoints that are being
-                    // retained.
-                    let removing = checkpoints_to_delete.len() < remove_count;
+                    // retained. Checkpoints in the retention set are always retained.
+                    let removing =
+                        !retained.contains(cid) && checkpoints_to_delete.len() < remove_count;
 
                     if removing {
                         checkpoints_to_delete.push(cid.clone());
@@ -1542,7 +1589,7 @@ mod tests {
     use incrementalmerkletree_testing::{
         arb_operation, check_append, check_checkpoint_rewind, check_operations, check_remove_mark,
         check_rewind_remove_mark, check_root_hashes, check_witness_consistency, check_witnesses,
-        complete_tree::CompleteTree, CombinedTree, SipHashable,
+        complete_tree::CompleteTree, compute_root_from_witness, CombinedTree, SipHashable,
     };
 
     use crate::{
@@ -1919,6 +1966,126 @@ mod tests {
 
         let witness = test_with_marking(Marking::Reference).unwrap();
         assert_eq!(witness, Some(expected_witness));
+    }
+
+    /// Builds a tree (`max_checkpoints == 3`) containing a `Marked` leaf at position 2 and an
+    /// explicitly-retained "anchor" checkpoint (id 1) at position 5, then advances the tree across
+    /// the shard boundary while adding more than `max_checkpoints` additional checkpoints, so that
+    /// checkpoint 1 would ordinarily be pruned were it not retained.
+    fn anchor_checkpoint_tree() -> ShardTree<MemoryShardStore<String, usize>, 6, 3> {
+        let mut tree = ShardTree::new(MemoryShardStore::empty(), 3);
+
+        // Append an initial series of leaves, marking the leaf at position 2 so that we can
+        // later compute a witness for it.
+        for c in 'a'..='e' {
+            let retention = if c == 'c' {
+                Retention::Marked
+            } else {
+                Retention::Ephemeral
+            };
+            tree.append(c.to_string(), retention).unwrap();
+        }
+
+        // Create a checkpoint (id 1) at position 5 and retain it explicitly so it becomes a
+        // durable anchor.
+        tree.append(
+            "f".to_string(),
+            Retention::Checkpoint {
+                id: 1,
+                marking: Marking::None,
+            },
+        )
+        .unwrap();
+        tree.ensure_retained(1).unwrap();
+
+        // Advance the tree across the shard boundary, adding ordinary checkpoints (ids 2..=5)
+        // such that checkpoint 1 ages more than `max_checkpoints` behind the tip.
+        let mut next_id = 2;
+        for c in 'g'..='n' {
+            let retention = if matches!(c, 'h' | 'j' | 'l' | 'n') {
+                let id = next_id;
+                next_id += 1;
+                Retention::Checkpoint {
+                    id,
+                    marking: Marking::None,
+                }
+            } else {
+                Retention::Ephemeral
+            };
+            tree.append(c.to_string(), retention).unwrap();
+        }
+
+        tree
+    }
+
+    #[test]
+    fn anchor_checkpoint_survives_pruning() {
+        let tree = anchor_checkpoint_tree();
+
+        // Three more recent ordinary checkpoints exist and `max_checkpoints` is 3, so an
+        // un-retained checkpoint in checkpoint 1's position would have been pruned. Because
+        // checkpoint 1 was explicitly retained, its record must be preserved.
+        assert_matches!(tree.store().get_checkpoint(&1), Ok(Some(_)));
+    }
+
+    #[test]
+    fn witness_marked_leaf_as_of_anchor_checkpoint() {
+        let tree = anchor_checkpoint_tree();
+
+        // The witness for the `Marked` leaf at position 2, as of the anchor checkpoint (id 1) at
+        // position 5, must remain computable even though checkpoint 1 has aged more than
+        // `max_checkpoints` behind the tip of the tree.
+        let expected_path: Vec<String> = [
+            "d",
+            "ab",
+            "ef__",
+            "________",
+            "________________",
+            "________________________________",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let witness = tree
+            .witness_at_checkpoint_id(Position::from(2), &1)
+            .unwrap()
+            .expect("a witness can be computed as of the anchored checkpoint");
+        assert_eq!(witness.path_elems(), expected_path.as_slice());
+
+        // The root as of the anchor checkpoint must also be computable, and must be consistent
+        // with the witness for the marked leaf.
+        let root = tree
+            .root_at_checkpoint_id(&1)
+            .unwrap()
+            .expect("a root can be computed as of the anchored checkpoint");
+        assert_eq!(
+            root,
+            compute_root_from_witness("c".to_string(), Position::from(2), &expected_path)
+        );
+    }
+
+    #[test]
+    fn released_anchor_checkpoint_is_pruned() {
+        let mut tree = anchor_checkpoint_tree();
+
+        // The anchor is retained, so it survives so far.
+        assert_matches!(tree.store().get_checkpoint(&1), Ok(Some(_)));
+
+        // Release the retention, then trigger pruning by adding another checkpoint. Checkpoint 1
+        // is now an ordinary checkpoint well beyond the `max_checkpoints` window, so it must be
+        // pruned.
+        tree.remove_retained_checkpoint(&1).unwrap();
+        tree.append(
+            "o".to_string(),
+            Retention::Checkpoint {
+                id: 6,
+                marking: Marking::None,
+            },
+        )
+        .unwrap();
+
+        assert_matches!(tree.store().get_checkpoint(&1), Ok(None));
     }
 
     // Combined tree tests

--- a/shardtree/src/store.rs
+++ b/shardtree/src/store.rs
@@ -139,6 +139,28 @@ pub trait ShardStore {
     /// If no checkpoint exists with the given ID, this does nothing.
     fn remove_checkpoint(&mut self, checkpoint_id: &Self::CheckpointId) -> Result<(), Self::Error>;
 
+    /// Adds the given checkpoint identifier to the set of checkpoints that must be retained when
+    /// pruning excess checkpoints.
+    ///
+    /// A retained checkpoint is excluded from the `max_checkpoints` budget and is never removed by
+    /// automatic pruning (see [`crate::ShardTree::prune_excess_checkpoints`]). The identifier may
+    /// be recorded even if no checkpoint with that identifier currently exists in the data store.
+    fn add_retained_checkpoint(
+        &mut self,
+        checkpoint_id: Self::CheckpointId,
+    ) -> Result<(), Self::Error>;
+
+    /// Removes the given checkpoint identifier from the set of retained checkpoints, allowing it to
+    /// be pruned normally. Has no effect if the identifier is not in the retention set.
+    fn remove_retained_checkpoint(
+        &mut self,
+        checkpoint_id: &Self::CheckpointId,
+    ) -> Result<(), Self::Error>;
+
+    /// Returns the set of checkpoint identifiers that have been marked for retention via
+    /// [`ShardStore::add_retained_checkpoint`].
+    fn retained_checkpoints(&self) -> Result<BTreeSet<Self::CheckpointId>, Self::Error>;
+
     /// Removes checkpoints with identifiers greater than to the given identifier, and removes mark
     /// removal metadata from the specified checkpoint.
     fn truncate_checkpoints_retaining(
@@ -244,6 +266,24 @@ impl<S: ShardStore> ShardStore for &mut S {
 
     fn remove_checkpoint(&mut self, checkpoint_id: &Self::CheckpointId) -> Result<(), Self::Error> {
         S::remove_checkpoint(self, checkpoint_id)
+    }
+
+    fn add_retained_checkpoint(
+        &mut self,
+        checkpoint_id: Self::CheckpointId,
+    ) -> Result<(), Self::Error> {
+        S::add_retained_checkpoint(self, checkpoint_id)
+    }
+
+    fn remove_retained_checkpoint(
+        &mut self,
+        checkpoint_id: &Self::CheckpointId,
+    ) -> Result<(), Self::Error> {
+        S::remove_retained_checkpoint(self, checkpoint_id)
+    }
+
+    fn retained_checkpoints(&self) -> Result<BTreeSet<Self::CheckpointId>, Self::Error> {
+        S::retained_checkpoints(self)
     }
 
     fn truncate_checkpoints_retaining(

--- a/shardtree/src/store/caching.rs
+++ b/shardtree/src/store/caching.rs
@@ -1,5 +1,6 @@
 //! Implementation of an in-memory shard store with persistence.
 
+use std::collections::BTreeSet;
 use std::convert::Infallible;
 
 use incrementalmerkletree::Address;
@@ -11,6 +12,7 @@ use crate::{LocatedPrunableTree, PrunableTree};
 enum Action<C> {
     TruncateShards(u64),
     RemoveCheckpoint(C),
+    RemoveRetainedCheckpoint(C),
     TruncateCheckpointsRetaining(C),
 }
 
@@ -69,6 +71,9 @@ where
                 Action::RemoveCheckpoint(checkpoint_id) => {
                     self.backend.remove_checkpoint(checkpoint_id)
                 }
+                Action::RemoveRetainedCheckpoint(checkpoint_id) => {
+                    self.backend.remove_retained_checkpoint(checkpoint_id)
+                }
                 Action::TruncateCheckpointsRetaining(checkpoint_id) => {
                     self.backend.truncate_checkpoints_retaining(checkpoint_id)
                 }
@@ -109,6 +114,14 @@ where
             .expect("error type is Infallible");
         for (checkpoint_id, checkpoint) in checkpoints {
             self.backend.add_checkpoint(checkpoint_id, checkpoint)?;
+        }
+
+        for checkpoint_id in self
+            .cache
+            .retained_checkpoints()
+            .expect("error type is Infallible")
+        {
+            self.backend.add_retained_checkpoint(checkpoint_id)?;
         }
 
         Ok(self.backend)
@@ -220,6 +233,26 @@ where
         self.deferred_actions
             .push(Action::RemoveCheckpoint(checkpoint_id.clone()));
         self.cache.remove_checkpoint(checkpoint_id)
+    }
+
+    fn add_retained_checkpoint(
+        &mut self,
+        checkpoint_id: Self::CheckpointId,
+    ) -> Result<(), Self::Error> {
+        self.cache.add_retained_checkpoint(checkpoint_id)
+    }
+
+    fn remove_retained_checkpoint(
+        &mut self,
+        checkpoint_id: &Self::CheckpointId,
+    ) -> Result<(), Self::Error> {
+        self.deferred_actions
+            .push(Action::RemoveRetainedCheckpoint(checkpoint_id.clone()));
+        self.cache.remove_retained_checkpoint(checkpoint_id)
+    }
+
+    fn retained_checkpoints(&self) -> Result<BTreeSet<Self::CheckpointId>, Self::Error> {
+        self.cache.retained_checkpoints()
     }
 
     fn truncate_checkpoints_retaining(

--- a/shardtree/src/store/memory.rs
+++ b/shardtree/src/store/memory.rs
@@ -1,6 +1,6 @@
 //! Implementation of an in-memory shard store with no persistence.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::{Infallible, TryFrom};
 
 use incrementalmerkletree::Address;
@@ -15,6 +15,7 @@ use crate::{LocatedPrunableTree, LocatedTree, PrunableTree, Tree};
 pub struct MemoryShardStore<H, C: Ord> {
     shards: Vec<LocatedPrunableTree<H>>,
     checkpoints: BTreeMap<C, Checkpoint>,
+    retained_checkpoints: BTreeSet<C>,
     cap: PrunableTree<H>,
 }
 
@@ -24,6 +25,7 @@ impl<H, C: Ord> MemoryShardStore<H, C> {
         Self {
             shards: vec![],
             checkpoints: BTreeMap::new(),
+            retained_checkpoints: BTreeSet::new(),
             cap: PrunableTree::empty(),
         }
     }
@@ -164,6 +166,20 @@ impl<H: Clone, C: Clone + Ord> ShardStore for MemoryShardStore<H, C> {
     fn remove_checkpoint(&mut self, checkpoint_id: &C) -> Result<(), Self::Error> {
         self.checkpoints.remove(checkpoint_id);
         Ok(())
+    }
+
+    fn add_retained_checkpoint(&mut self, checkpoint_id: C) -> Result<(), Self::Error> {
+        self.retained_checkpoints.insert(checkpoint_id);
+        Ok(())
+    }
+
+    fn remove_retained_checkpoint(&mut self, checkpoint_id: &C) -> Result<(), Self::Error> {
+        self.retained_checkpoints.remove(checkpoint_id);
+        Ok(())
+    }
+
+    fn retained_checkpoints(&self) -> Result<BTreeSet<C>, Self::Error> {
+        Ok(self.retained_checkpoints.clone())
     }
 
     fn truncate_checkpoints_retaining(


### PR DESCRIPTION
## Summary

Adds the ability to explicitly **retain** a checkpoint so that it is exempt from automatic pruning of excess checkpoints. A retained checkpoint's root — and witnesses for `Marked` leaves at or before it — remain computable even after it has aged more than `max_checkpoints` behind the tip of the tree. Retention is releasable.

This supersedes the earlier draft #95 ("Add the ability to avoid pruning specific checkpoints"): same explicit-retention idea, rebased onto current `main` and simplified (no `Reference`/marking changes, no public `incrementalmerkletree` API change).

## API

- `ShardTree::ensure_retained(checkpoint_id)` — mark a checkpoint for retention (the id may be recorded even if no such checkpoint currently exists).
- `ShardTree::remove_retained_checkpoint(&checkpoint_id)` — release it.
- `ShardStore`: `add_retained_checkpoint` / `remove_retained_checkpoint` / `retained_checkpoints` (the id-keyed retention set; implemented for `MemoryShardStore` and the caching store).

`prune_excess_checkpoints` excludes retained checkpoints from the `max_checkpoints` budget and never auto-removes them; it loads the retention set once rather than querying per checkpoint.

## Why no `Reference` retention is needed

Computing a witness for a marked leaf as of checkpoint `R` truncates the tree at `R + 1`. The only subtree truncation cuts through is the one straddling position `R`, which contains the anchor's own leaf — and its `CHECKPOINT` retention (kept because the checkpoint is retained) propagates through merges and prevents that subtree from collapsing. Every other sibling subtree is either wholly ≤ `R` (its aggregate hash is valid) or wholly > `R` (forced empty). So record retention plus the inherent `CHECKPOINT` protection is sufficient; no `Reference`/leaf marking is required, and the public `incrementalmerkletree` `Marking`/`Retention` API is unchanged.

## Tests

- `anchor_checkpoint_survives_pruning` — a retained checkpoint survives pruning that would remove an ordinary checkpoint in the same position.
- `witness_marked_leaf_as_of_anchor_checkpoint` — the motivating scenario: a `Marked` leaf is witnessed (and the root computed) as of a retained checkpoint that has aged more than `max_checkpoints` behind the tip.
- `released_anchor_checkpoint_is_pruned` — after `remove_retained_checkpoint`, the checkpoint is pruned normally.

## Related

The investigation behind this surfaced a separate concern in the wallet's use of frontier `Marking::Reference` retention (unbounded accumulation during forward sync): zcash/librustzcash#2503.

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
