### PR TITLE
shardtree: seed CachingShardStore's retention set at load

### DIFF
--- a/shardtree/src/store/caching.rs
+++ b/shardtree/src/store/caching.rs
@@ -55,6 +55,13 @@ where
                 .expect("error type is Infallible");
             Ok(())
         })?;
+        // Seed the retention set so that pruning performed through the overlay observes the
+        // backend's durable anchors (a retained checkpoint must never be pruned).
+        for checkpoint_id in backend.retained_checkpoints()? {
+            cache
+                .add_retained_checkpoint(checkpoint_id)
+                .expect("error type is Infallible");
+        }
 
         Ok(Self {
             backend,
@@ -301,6 +308,28 @@ mod tests {
             },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn load_seeds_retained_checkpoints() {
+        use std::collections::BTreeSet;
+
+        use crate::store::Checkpoint;
+
+        let mut backend = MemoryShardStore::<String, u64>::empty();
+        backend.add_checkpoint(5, Checkpoint::tree_empty()).unwrap();
+        backend.add_retained_checkpoint(5).unwrap();
+
+        // The overlay must observe the backend's durable retention set: pruning performed
+        // through the overlay (`ShardTree::prune_excess_checkpoints`) consults
+        // `retained_checkpoints` to decide what it may remove, so a checkpoint retained in
+        // the backend but invisible to the cache could be pruned away.
+        let store = CachingShardStore::load(backend).unwrap();
+        assert_eq!(store.retained_checkpoints().unwrap(), BTreeSet::from([5]));
+
+        // A load -> flush round trip must also preserve the retention marker.
+        let backend = store.flush().unwrap();
+        assert_eq!(backend.retained_checkpoints().unwrap(), BTreeSet::from([5]));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #188.

`CachingShardStore::load` copied shards, the cap and checkpoints into its in-memory cache, but not the backend's retained-checkpoint set, so `retained_checkpoints()` on a freshly-loaded overlay reported an empty set regardless of backend state — and pruning performed through the overlay could therefore remove a durable anchor's checkpoint (the deferred removal then replays onto the backend at flush).

The fix seeds the cache's retention set from the backend at load, mirroring how shards, the cap and checkpoints are copied. A regression test covers both the load itself and the load → flush round trip.

No changelog entry: this repairs behavior introduced by #184, which is unreleased.

Found while rebasing #181 (`SparseCachingShardStore` handles its retention set the same way in `with_preloaded`).