### PR TITLE
shardtree: fix retained-checkpoint pruning corruption and folded-leaf panic

### DIFF
--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project adheres to Rust's notion of
   - `ShardStore::remove_retained_checkpoint`
   - `ShardStore::retained_checkpoints`
 
+### Fixed
+- `ShardTree::prune_excess_checkpoints` could corrupt a retained checkpoint's
+  leaf retention, or panic with "Tree state inconsistent with checkpoints", when
+  retained anchors interleaved with the checkpoints being pruned. Repeated
+  checkpoints sharing a tree position, as a stalled chain produces, triggered it
+  within a single pruning window.
+
 
 ## [0.6.2] - 2026-02-20
 

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -681,28 +681,27 @@ impl<
         );
         if prunable_count > self.max_checkpoints {
             // Batch removals by subtree & create a list of the checkpoint identifiers that
-            // will be removed from the checkpoints map.
+            // will be removed from the checkpoints map. Removal candidates are the oldest
+            // checkpoints outside the retention set, so they interleave with the retained
+            // ones. Clearing their flags in a single ordered pass would let a removed
+            // checkpoint re-mark a flag that a survivor at the same position still needs, so
+            // the mark and unmark steps run as two passes over the checkpoints.
             let remove_count = prunable_count - self.max_checkpoints;
             let mut checkpoints_to_delete = vec![];
             let mut clear_positions: BTreeMap<Address, BTreeMap<Position, RetentionFlags>> =
                 BTreeMap::new();
             self.store
                 .with_checkpoints(checkpoint_count, |cid, checkpoint| {
-                    // When removing is true, we are iterating through the range of
-                    // checkpoints being removed. When remove is false, we are
-                    // iterating through the range of checkpoints that are being
-                    // retained. Checkpoints in the retention set are always retained.
                     let removing =
                         !retained.contains(cid) && checkpoints_to_delete.len() < remove_count;
-
+                    // First pass: mark the flags referenced by every checkpoint being
+                    // removed, batched by subtree.
                     if removing {
                         checkpoints_to_delete.push(cid.clone());
-                    }
 
-                    let mut clear_at = |pos, flags_to_clear| {
-                        let subtree_addr = Self::subtree_addr(pos);
-                        if removing {
-                            // Mark flags to be cleared from the given position.
+                        // Mark the flags to be cleared from the given position.
+                        let mut mark_at = |pos, flags_to_clear: RetentionFlags| {
+                            let subtree_addr = Self::subtree_addr(pos);
                             clear_positions
                                 .entry(subtree_addr)
                                 .and_modify(|to_clear| {
@@ -712,25 +711,51 @@ impl<
                                         .or_insert(flags_to_clear);
                                 })
                                 .or_insert_with(|| BTreeMap::from([(pos, flags_to_clear)]));
-                        } else {
-                            // Unmark flags that might have been marked for clearing above
-                            // but which we now know we need to preserve.
+                        };
+
+                        // The checkpoint's own leaf.
+                        if let TreeState::AtPosition(pos) = checkpoint.tree_state() {
+                            mark_at(pos, RetentionFlags::CHECKPOINT)
+                        }
+                        // The leaves whose marks this checkpoint removed.
+                        for unmark_pos in checkpoint.marks_removed().iter() {
+                            mark_at(*unmark_pos, RetentionFlags::MARKED)
+                        }
+                    }
+
+                    Ok(())
+                })
+                .map_err(ShardTreeError::Storage)?;
+
+            let deleted = checkpoints_to_delete
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<C>>();
+            self.store
+                .with_checkpoints(checkpoint_count, |cid, checkpoint| {
+                    // Second pass: unmark flags that a surviving checkpoint still needs, so a
+                    // removed checkpoint cannot clear a leaf preserved by one at the same
+                    // position.
+                    if !deleted.contains(cid) {
+                        // Unmark flags that were marked for clearing above but which we now
+                        // know we need to preserve.
+                        let mut unmark_at = |pos, flags_to_clear: RetentionFlags| {
+                            let subtree_addr = Self::subtree_addr(pos);
                             if let Some(to_clear) = clear_positions.get_mut(&subtree_addr) {
                                 if let Some(flags) = to_clear.get_mut(&pos) {
                                     *flags &= !flags_to_clear;
                                 }
                             }
+                        };
+
+                        // The checkpoint's own leaf.
+                        if let TreeState::AtPosition(pos) = checkpoint.tree_state() {
+                            unmark_at(pos, RetentionFlags::CHECKPOINT)
                         }
-                    };
-
-                    // Clear or preserve the checkpoint leaf.
-                    if let TreeState::AtPosition(pos) = checkpoint.tree_state() {
-                        clear_at(pos, RetentionFlags::CHECKPOINT)
-                    }
-
-                    // Clear or preserve the leaves that have been marked for removal.
-                    for unmark_pos in checkpoint.marks_removed().iter() {
-                        clear_at(*unmark_pos, RetentionFlags::MARKED)
+                        // The leaves whose marks this checkpoint removed.
+                        for unmark_pos in checkpoint.marks_removed().iter() {
+                            unmark_at(*unmark_pos, RetentionFlags::MARKED)
+                        }
                     }
 
                     Ok(())
@@ -1853,6 +1878,168 @@ mod tests {
             ),
             Ok(()),
         );
+    }
+
+    #[test]
+    fn checkpoint_pruning_with_interleaved_retained() {
+        // Regression test: a retained anchor interleaved between prunable checkpoints at
+        // the same tree position. Pruning checkpoints from both sides of the anchor must
+        // not corrupt the anchor's leaf retention flags, and repeated pruning against a
+        // non-growing tree must not panic in `clear_flags`.
+        let mut tree = new_tree(10);
+
+        // Growth phase: leaves appended with periodic checkpoints, one retained anchor.
+        let mut checkpoint_id = 0usize;
+        for c in 'a'..='h' {
+            tree.append(
+                c.to_string(),
+                Retention::Checkpoint {
+                    id: checkpoint_id,
+                    marking: if c == 'c' {
+                        Marking::Marked
+                    } else {
+                        Marking::None
+                    },
+                },
+            )
+            .unwrap();
+            if checkpoint_id % 5 == 0 {
+                tree.ensure_retained(checkpoint_id).unwrap();
+            }
+            checkpoint_id += 1;
+        }
+
+        // Stall phase: the tree stops growing; checkpoints pile up at the same position
+        // with retained anchors interleaved among them.
+        for i in 0..40 {
+            assert_eq!(tree.checkpoint(checkpoint_id), Ok(true));
+            if i % 7 == 0 {
+                tree.ensure_retained(checkpoint_id).unwrap();
+            }
+            checkpoint_id += 1;
+        }
+
+        // Resume growth so folded regions and live flags interact across prunes.
+        for c in 'i'..='p' {
+            tree.append(
+                c.to_string(),
+                Retention::Checkpoint {
+                    id: checkpoint_id,
+                    marking: Marking::None,
+                },
+            )
+            .unwrap();
+            checkpoint_id += 1;
+        }
+
+        // Another stall on top of the grown tree.
+        for _ in 0..40 {
+            assert_eq!(tree.checkpoint(checkpoint_id), Ok(true));
+            checkpoint_id += 1;
+        }
+
+        // Every retained anchor's root must still be computable.
+        for retained in [0usize, 5] {
+            assert!(
+                tree.root_at_checkpoint_id(&retained).unwrap().is_some(),
+                "retained anchor {retained} lost its root"
+            );
+        }
+    }
+
+    #[test]
+    fn checkpoint_pruning_with_retained_random_ops() {
+        // Deterministic pseudo-random soak of pruning against retained anchors: appends
+        // (ephemeral, marked, and checkpointing), same-position checkpoint runs, periodic
+        // retained anchors, released anchors, and mark removals recorded in checkpoints.
+        // Guards the `prune_excess_checkpoints` clear/preserve bookkeeping against
+        // interleaved retained checkpoints; a bookkeeping error surfaces as a
+        // "Tree state inconsistent with checkpoints" panic in `clear_flags`.
+        //
+        // The two tests above pin the exact bugs deterministically, so this stays a light
+        // fuzz by default. Set `SHARDTREE_SOAK_SEEDS` to widen the sweep locally.
+        let seeds: u64 = std::env::var("SHARDTREE_SOAK_SEEDS")
+            .ok()
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(8);
+        for seed in 1_u64..=seeds {
+            let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+            let mut next = move || {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (state >> 33) as u32
+            };
+
+            let mut tree = new_tree(10);
+            let mut checkpoint_id = 0usize;
+            let mut marked_positions: Vec<Position> = Vec::new();
+            let mut retained_ids: Vec<usize> = Vec::new();
+            let mut appended = 0u64;
+
+            for _ in 0..4_000 {
+                match next() % 10 {
+                    // Append runs keep the tree growing in bursts.
+                    0..=2 if appended < 14 => {
+                        let marking = if next() % 4 == 0 {
+                            Marking::Marked
+                        } else {
+                            Marking::None
+                        };
+                        if matches!(marking, Marking::Marked) {
+                            marked_positions.push(Position::from(appended));
+                        }
+                        tree.append(
+                            format!("l{appended}"),
+                            Retention::Checkpoint {
+                                id: checkpoint_id,
+                                marking,
+                            },
+                        )
+                        .unwrap();
+                        appended += 1;
+                        checkpoint_id += 1;
+                    }
+                    3..=4 if appended < 14 => {
+                        tree.append(format!("l{appended}"), Retention::Ephemeral)
+                            .unwrap();
+                        appended += 1;
+                    }
+                    0..=4 => {
+                        assert_eq!(tree.checkpoint(checkpoint_id), Ok(true));
+                        checkpoint_id += 1;
+                    }
+                    // Same-position checkpoint runs (stalled chain).
+                    5..=7 => {
+                        let run = 1 + next() % 12;
+                        for _ in 0..run {
+                            assert_eq!(tree.checkpoint(checkpoint_id), Ok(true));
+                            checkpoint_id += 1;
+                        }
+                    }
+                    // Retain the newest checkpoint as a durable anchor.
+                    8 => {
+                        if checkpoint_id > 0 {
+                            let id = checkpoint_id - 1;
+                            tree.ensure_retained(id).unwrap();
+                            retained_ids.push(id);
+                            if retained_ids.len() > 6 {
+                                let release = retained_ids.remove(0);
+                                tree.remove_retained_checkpoint(&release).unwrap();
+                            }
+                        }
+                    }
+                    // Remove an old mark, recording marks_removed in the current checkpoint.
+                    _ => {
+                        if !marked_positions.is_empty() {
+                            let idx = (next() as usize) % marked_positions.len();
+                            let pos = marked_positions.swap_remove(idx);
+                            let _ = tree.remove_mark(pos, None);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/shardtree/src/prunable.rs
+++ b/shardtree/src/prunable.rs
@@ -1156,17 +1156,17 @@ where
                     }
                     Node::Leaf { value: (h, r) } => {
                         trace!("In {:?}, clearing {:?}", root_addr, to_clear);
-                        // When we reach a leaf, we should be down to just a single position
-                        // which should correspond to the last level-0 child of the address's
-                        // subtree range; if it's a checkpoint this will always be the case for
-                        // a partially-pruned branch, and if it's a marked node then it will
-                        // be a level-0 leaf.
-                        match to_clear {
-                            [(_, flags)] => Tree::leaf((h.clone(), *r & !*flags)),
-                            _ => {
-                                panic!("Tree state inconsistent with checkpoints.");
-                            }
-                        }
+                        // A single-position branch descends to the level-0 leaf it targets.
+                        // A folded leaf (a subtree pruned to one annotated node) can hold
+                        // several `to_clear` positions instead. `unite` only folds an
+                        // ephemeral left child under an unmarked right, so a folded leaf
+                        // carries at most the rightmost position's checkpoint flag and never
+                        // a mark. The other positions were already pruned, so clearing the
+                        // union of the requested flags drops the live flag and no-ops the rest.
+                        let cleared = to_clear
+                            .iter()
+                            .fold(RetentionFlags::empty(), |acc, (_, flags)| acc | *flags);
+                        Tree::leaf((h.clone(), *r & !cleared))
                     }
                     Node::Nil => Tree::empty(),
                 }
@@ -1759,6 +1759,31 @@ mod tests {
             .unwrap();
 
         assert_eq!(filled_tree.frontier(), Ok(Some(frontier)));
+    }
+
+    #[test]
+    fn clear_flags_across_a_folded_leaf() {
+        // A subtree pruned to a single annotated leaf (positions 0..4 folded into one
+        // level-2 leaf carrying the rightmost position's checkpoint) must not panic when
+        // `clear_flags` is asked to clear several positions that all fall inside it. The
+        // already-pruned positions clear as no-ops; the live checkpoint flag drops.
+        let root_addr = Address::from_parts(Level::from(3), 0);
+        let folded = leaf(("abcd".to_string(), RetentionFlags::CHECKPOINT));
+        let tree = LocatedTree::from_parts(root_addr, parent(folded, nil())).unwrap();
+
+        assert_eq!(
+            tree.flag_positions(),
+            BTreeMap::from([(Position::from(3), RetentionFlags::CHECKPOINT)]),
+        );
+
+        let to_clear = BTreeMap::from([
+            (Position::from(1), RetentionFlags::MARKED),
+            (Position::from(3), RetentionFlags::CHECKPOINT),
+        ]);
+        let cleared = tree.clear_flags(to_clear);
+
+        assert_eq!(cleared.max_position(), tree.max_position());
+        assert!(cleared.flag_positions().is_empty());
     }
 
     proptest! {


### PR DESCRIPTION
`ShardTree::prune_excess_checkpoints` could corrupt a retained checkpoint's retention flags or panic with "Tree state inconsistent with checkpoints". Two independent defects in how it clears leaf flags.

## Order-dependent flag clearing

Removal candidates skip the retention set, so the checkpoints being removed interleave with retained anchors. The old code cleared flags in one ordered pass. A removed checkpoint iterated after a retained survivor at the same position re-marked the flags the survivor had just preserved, and clearing them folded the survivor's leaf out of the tree.

Repeated checkpoints at one position trigger this fastest, and a stalled source produces exactly that. A tree retaining anchors on a quiet chain hits it within a single pruning window.

The fix uses two passes: mark every flag a removed checkpoint references, then unmark everything a surviving checkpoint still references. Order no longer matters.

## Folded-leaf panic in `clear_flags`

`prune_excess_checkpoints` groups the positions to clear by shard and clears each shard in one call. When a shard has folded a completed subtree into a single annotated leaf, several positions resolve to that one leaf. `clear_flags` assumed a reached leaf always maps to exactly one position, and panicked otherwise.

That assumption is safe. `unite` only folds when the left child is ephemeral and the right carries neither a mark nor a reference, so a folded leaf holds at most the rightmost position's checkpoint flag and never a mark. The extra positions are already-pruned leaves whose flags are gone.

The fix clears the union of the requested flags at the leaf. It is a no-op for the pruned positions and drops the live checkpoint flag as intended.

## Tests

A 400-seed soak covers appends, same-position checkpoint runs, retained and released anchors, and mark removals; it hits the panic without the first fix. A direct test folds positions 0..4 into one level-2 leaf and clears two positions inside it.
