### PR TITLE
shardtree: discard stale state when truncating

### DIFF
--- a/shardtree/CHANGELOG.md
+++ b/shardtree/CHANGELOG.md
@@ -5,6 +5,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- `shardtree::LocatedPrunableTree::truncate_to_position` no longer leaves stale
+  state from the discarded suffix of the tree in place:
+  - Parent nodes reconstructed along the truncation path now have their cached
+    root annotations discarded. Such an annotation is a hash over the parent's
+    complete subtree — including the data being truncated away — and a stale
+    annotation caused spurious `Insert(Conflict(..))` errors (or silently
+    incorrect roots) when the truncated region was later refilled with
+    different data, e.g. when re-scanning a divergent chain after a reorg.
+  - When the truncation position falls in the interior of a pruned subtree
+    whose leaves have been merged into a single hash, the merged node (whose
+    hash incorporates discarded data, and whose constituent parts cannot be
+    recovered) is now replaced by `Nil` instead of the truncation being
+    refused. Previously `ShardTree::truncate_to_checkpoint` reacted to the
+    refusal by silently skipping the shard and checkpoint truncation — after
+    having already truncated the cap — while still reporting success.
+- `ShardTree::truncate_to_checkpoint` and
+  `ShardTree::truncate_to_checkpoint_depth` now always remove the shards,
+  and the checkpoints, that lie beyond the checkpoint being truncated to,
+  even if the boundary shard itself is absent from the store.
+
 ## [0.7.0] - 2026-07-09
 
 ### Added

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -881,17 +881,17 @@ impl<
                         .map_err(ShardTreeError::Storage)?;
                 };
 
+                self.store
+                    .truncate_shards(subtree_addr.index())
+                    .map_err(ShardTreeError::Storage)?;
                 if let Some(truncated) = replacement {
-                    self.store
-                        .truncate_shards(subtree_addr.index())
-                        .map_err(ShardTreeError::Storage)?;
                     self.store
                         .put_shard(truncated)
                         .map_err(ShardTreeError::Storage)?;
-                    self.store
-                        .truncate_checkpoints_retaining(checkpoint_id)
-                        .map_err(ShardTreeError::Storage)?;
                 }
+                self.store
+                    .truncate_checkpoints_retaining(checkpoint_id)
+                    .map_err(ShardTreeError::Storage)?;
             }
         }
 

--- a/shardtree/src/lib.rs
+++ b/shardtree/src/lib.rs
@@ -1657,12 +1657,12 @@ mod tests {
 
     use crate::{
         error::{QueryError, ShardTreeError},
-        store::{memory::MemoryShardStore, ShardStore},
+        store::{memory::MemoryShardStore, Checkpoint, ShardStore},
         testing::{
             arb_char_str, arb_shard_layout, arb_shardtree_sized, check_shard_sizes,
             check_shardtree_insertion, check_witness_with_pruned_subtrees,
         },
-        InsertionError, LocatedPrunableTree, LocatedTree, ShardTree,
+        InsertionError, LocatedPrunableTree, LocatedTree, RetentionFlags, ShardTree, Tree,
     };
 
     #[test]
@@ -2484,6 +2484,131 @@ mod tests {
         assert_matches!(
             tree2.insert_frontier_nodes::<()>(frontier, &Retention::Ephemeral),
             Err(InsertionError::Conflict(_))
+        );
+    }
+
+    #[test]
+    fn truncate_to_checkpoint_discards_stale_annotations() {
+        // Regression test: `LocatedPrunableTree::truncate_to_position` reconstructed
+        // the parent nodes along the truncation path with their cached root annotations
+        // intact. Such an annotation is a hash over the parent's complete subtree —
+        // including the data being truncated away — so a retained annotation caused
+        // spurious `Conflict` errors (or silently incorrect roots) once the truncated
+        // region was refilled with different data, as happens when a wallet re-scans a
+        // divergent chain after a reorg.
+        let mut tree = empty_tree::<String, 4, 2>();
+
+        // The original chain: leaves at positions 0..=5, checkpointed at positions 4
+        // and 5.
+        for (leaf, retention) in [
+            ("a", Retention::Ephemeral),
+            ("b", Retention::Ephemeral),
+            ("c", Retention::Ephemeral),
+            ("d", Retention::Ephemeral),
+            (
+                "e",
+                Retention::Checkpoint {
+                    id: 1,
+                    marking: Marking::None,
+                },
+            ),
+            (
+                "f",
+                Retention::Checkpoint {
+                    id: 2,
+                    marking: Marking::None,
+                },
+            ),
+        ] {
+            tree.append(leaf.to_string(), retention).unwrap();
+        }
+
+        // Inserting a frontier at position 6 (as a wallet does with the chain state at
+        // the start of each scanned batch) writes the frontier's ommers into the tree;
+        // the ommer covering positions 4..=5 is recorded as a cached annotation on the
+        // existing parent node for those positions.
+        tree.insert_frontier(
+            Frontier::from_parts(
+                Position::from(6),
+                "g".to_string(),
+                vec!["ef".to_string(), "abcd".to_string()],
+            )
+            .unwrap(),
+            Retention::Checkpoint {
+                id: 3,
+                marking: Marking::None,
+            },
+        )
+        .unwrap();
+
+        // Truncate back to the checkpoint at position 4, discarding the data at
+        // positions 5 and 6.
+        assert!(tree.truncate_to_checkpoint(&1).unwrap());
+
+        // On the divergent chain, positions 5 and 6 hold different leaves. Inserting
+        // its frontier must succeed: nothing of the discarded chain may remain in the
+        // tree to conflict with the replacement data.
+        tree.insert_frontier(
+            Frontier::from_parts(
+                Position::from(6),
+                "y".to_string(),
+                vec!["ex".to_string(), "abcd".to_string()],
+            )
+            .unwrap(),
+            Retention::Checkpoint {
+                id: 4,
+                marking: Marking::None,
+            },
+        )
+        .unwrap();
+
+        // The tree's state at the new checkpoint reflects the divergent chain.
+        assert_eq!(
+            tree.root_at_checkpoint_id(&4).unwrap(),
+            Some("abcdexy_________".to_string()),
+        );
+    }
+
+    #[test]
+    fn truncate_to_checkpoint_within_pruned_subtree() {
+        // Regression test: when the checkpoint's position fell in the interior of a
+        // pruned subtree (a merged hash node), `truncate_to_position` returned `None`,
+        // and `truncate_to_checkpoint` reacted by silently skipping the shard and
+        // checkpoint truncation — after having already truncated the cap — while still
+        // reporting success, leaving all post-checkpoint state in place.
+        let mut tree = empty_tree::<String, 4, 2>();
+        tree.store
+            .put_shard(LocatedTree {
+                root_addr: Address::from_parts(Level::from(2), 0),
+                root: Tree::parent(
+                    None,
+                    Tree::leaf(("ab".to_string(), RetentionFlags::EPHEMERAL)),
+                    Tree::leaf(("cd".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+            })
+            .unwrap();
+        tree.store
+            .add_checkpoint(1, Checkpoint::at_position(Position::from(0)))
+            .unwrap();
+        tree.store
+            .add_checkpoint(2, Checkpoint::at_position(Position::from(3)))
+            .unwrap();
+
+        assert!(tree.truncate_to_checkpoint(&1).unwrap());
+
+        // The checkpoint at position 3 must have been removed...
+        assert_eq!(tree.store.checkpoint_count().unwrap(), 1);
+
+        // ...and no data above position 0 may survive. The merged node containing
+        // position 0 incorporates data above the truncation position, so it is
+        // discarded along with everything else; its contents can be restored by
+        // re-insertion.
+        assert_eq!(
+            tree.store
+                .get_shard(Address::from_parts(Level::from(2), 0))
+                .unwrap()
+                .map(|s| s.root),
+            Some(Tree::empty()),
         );
     }
 

--- a/shardtree/src/prunable.rs
+++ b/shardtree/src/prunable.rs
@@ -731,24 +731,37 @@ where
         }
     }
 
-    /// Prunes this tree by replacing all nodes that are right-hand children along the path
-    /// to the specified position with [`Node::Nil`].
+    /// Truncates this tree by discarding all data at positions greater than `position`.
     ///
-    /// The leaf at the specified position is retained. Returns the truncated tree if a leaf or
-    /// subtree root with the specified position as its maximum position exists, or `None`
-    /// otherwise.
+    /// The leaf at `position`, and all data at lesser positions, is retained wherever it is
+    /// individually represented in the tree. If `position` falls in the interior of a pruned
+    /// subtree — one whose leaves have been merged into a single hash — that subtree is
+    /// replaced by [`Node::Nil`]: its hash incorporates discarded data, and its constituent
+    /// parts cannot be recovered. Cached root annotations of parent nodes whose subtrees lose
+    /// data in the truncation are likewise discarded, since such an annotation is a hash over
+    /// the parent's complete subtree. Roots and witnesses that depend upon a discarded range
+    /// will be unavailable until its contents are re-inserted.
+    ///
+    /// Returns `None` if `position` is outside the position range of this tree.
     pub fn truncate_to_position(&self, position: Position) -> Option<Self> {
         /// Pre-condition: `root_addr` must be the address of `root`.
-        fn go<H>(
-            position: Position,
-            root_addr: Address,
-            root: &PrunableTree<H>,
-        ) -> Option<PrunableTree<H>>
+        fn go<H>(position: Position, root_addr: Address, root: &PrunableTree<H>) -> PrunableTree<H>
         where
             H: Hashable + Clone + PartialEq,
         {
+            if root_addr.max_position() <= position {
+                // Nothing above `position` exists within this subtree, so it is retained
+                // unmodified, along with any cached root annotation.
+                return root.clone();
+            }
             match &root.0 {
-                Node::Parent { ann, left, right } => {
+                Node::Parent {
+                    ann: _,
+                    left,
+                    right,
+                } => {
+                    // This node's subtree loses data in the truncation, so any cached root
+                    // annotation for it (a hash over its complete subtree) is discarded.
                     let (l_child, r_child) = root_addr
                         .children()
                         .expect("has children because we checked `root` is a parent");
@@ -756,33 +769,40 @@ where
                         // we are truncating within the range of the left node, so recurse
                         // to the left to truncate the left child and then reconstruct the
                         // node with `Nil` as the right sibling
-                        go(position, l_child, left.as_ref()).map(|left| {
-                            Tree::unite(l_child.level(), ann.clone(), left, Tree::empty())
-                        })
+                        Tree::unite(
+                            l_child.level(),
+                            None,
+                            go(position, l_child, left.as_ref()),
+                            Tree::empty(),
+                        )
                     } else {
                         // we are truncating within the range of the right node, so recurse
                         // to the right to truncate the right child and then reconstruct the
                         // node with the left sibling unchanged
-                        go(position, r_child, right.as_ref()).map(|right| {
-                            Tree::unite(r_child.level(), ann.clone(), left.as_ref().clone(), right)
-                        })
+                        Tree::unite(
+                            r_child.level(),
+                            None,
+                            left.as_ref().clone(),
+                            go(position, r_child, right.as_ref()),
+                        )
                     }
                 }
-                Node::Leaf { .. } => {
-                    if root_addr.max_position() <= position {
-                        Some(root.clone())
-                    } else {
-                        None
-                    }
-                }
-                Node::Nil => None,
+                // The truncation position falls in the interior of a pruned subtree whose
+                // leaves have been merged into a single hash. The merged hash incorporates
+                // discarded data, and the constituent parts from which a replacement hash
+                // could be computed are unrecoverable, so the node must be discarded. It can
+                // be restored by re-insertion of the subtree's contents.
+                Node::Leaf { .. } => Tree::empty(),
+                // The subtree contains no data at all; in particular, nothing above
+                // `position`.
+                Node::Nil => Tree::empty(),
             }
         }
 
         if self.root_addr.position_range().contains(&position) {
-            go(position, self.root_addr, &self.root).map(|root| LocatedTree {
+            Some(LocatedTree {
                 root_addr: self.root_addr,
-                root,
+                root: go(position, self.root_addr, &self.root),
             })
         } else {
             None

--- a/shardtree/src/prunable.rs
+++ b/shardtree/src/prunable.rs
@@ -1315,7 +1315,7 @@ mod tests {
         testing::{arb_char_str, arb_prunable_tree},
         tree::{
             tests::{leaf, nil, parent},
-            LocatedTree,
+            LocatedTree, Tree,
         },
     };
 
@@ -1386,6 +1386,81 @@ mod tests {
                 leaf(("c".to_string(), RetentionFlags::MARKED)),
                 leaf(("ab".to_string(), RetentionFlags::EPHEMERAL))
             )
+        );
+    }
+
+    #[test]
+    fn truncate_to_position_discards_annotations() {
+        use std::sync::Arc;
+
+        // A cached annotation on a parent node is a hash over the parent's complete
+        // subtree — including any data above the truncation position — so truncation
+        // along a path through an annotated parent must discard the annotation.
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(Level::from(2), 0),
+            root: Tree::parent(
+                Some(Arc::new("abcd".to_string())),
+                parent(
+                    leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+                parent(
+                    leaf(("c".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("d".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+            ),
+        };
+
+        let truncated = t
+            .truncate_to_position(Position::from(1))
+            .expect("position is in range");
+        assert_eq!(
+            truncated.root,
+            Tree::parent(
+                None,
+                parent(
+                    leaf(("a".to_string(), RetentionFlags::EPHEMERAL)),
+                    leaf(("b".to_string(), RetentionFlags::EPHEMERAL)),
+                ),
+                nil()
+            )
+        );
+
+        // Truncating at the tree's max position removes nothing: the tree is retained
+        // unchanged, including its cached annotations.
+        let untouched = t
+            .truncate_to_position(Position::from(3))
+            .expect("position is in range");
+        assert_eq!(untouched.root, t.root);
+    }
+
+    #[test]
+    fn truncate_to_position_inside_pruned_subtree_discards_it() {
+        // When the truncation position falls in the interior of a pruned subtree whose
+        // leaves have been merged into a single hash, the merged hash incorporates data
+        // above the truncation position and its constituent parts cannot be recovered,
+        // so the node must be discarded — not retained, and not cause the truncation to
+        // be refused.
+        let t: LocatedPrunableTree<String> = LocatedTree {
+            root_addr: Address::from_parts(Level::from(2), 0),
+            root: parent(
+                leaf(("ab".to_string(), RetentionFlags::EPHEMERAL)),
+                leaf(("cd".to_string(), RetentionFlags::EPHEMERAL)),
+            ),
+        };
+
+        let truncated = t
+            .truncate_to_position(Position::from(0))
+            .expect("position is in range");
+        assert_eq!(truncated.root, nil());
+
+        // Truncating at the merged node's max position retains it whole.
+        let truncated = t
+            .truncate_to_position(Position::from(1))
+            .expect("position is in range");
+        assert_eq!(
+            truncated.root,
+            parent(leaf(("ab".to_string(), RetentionFlags::EPHEMERAL)), nil())
         );
     }
 


### PR DESCRIPTION
This fixes two defects in `LocatedPrunableTree::truncate_to_position` that left a truncated tree poisoned with state derived from the discarded suffix, discovered while testing wallet reorg recovery in librustzcash:

1. **Stale cached annotations survived truncation.** The parent nodes reconstructed along the truncation path retained their cached root annotations. Such an annotation is a hash over the parent's complete subtree — including the data being truncated away — so a retained annotation caused a spurious `Insert(Conflict(..))` error (or a silently incorrect root) once the truncated region was refilled with different data. Annotations of this shape are routinely written by `insert_frontier`, which wallets invoke with the chain state at the start of every scanned batch, so any wallet that rewinds past a scan-batch boundary and then re-scans a divergent (post-reorg) chain can hit this.

2. **Truncation inside a pruned subtree was silently skipped.** When the truncation position fell in the interior of a pruned subtree (a merged hash node), `truncate_to_position` returned `None`, and `truncate_to_checkpoint` reacted by skipping the shard and checkpoint truncation — after having already truncated the cap — while still reporting success, leaving the store internally inconsistent with all post-checkpoint state in place.

The fix:

- A subtree lying entirely at or below the truncation position is retained unmodified (including its still-valid annotations); this check is now made once at the top of the recursion, generalizing the check previously made only for pruned leaf nodes.
- Parent nodes whose subtrees lose data in the truncation are reconstructed without their annotations.
- A merged node whose hash spans the truncation position is replaced by `Nil`: the hash incorporates discarded data and its constituent parts are unrecoverable. Roots and witnesses over that range become unavailable until the range's contents are re-inserted, instead of being computed from stale data.
- With refusal no longer a possible outcome for an in-range position, `truncate_to_checkpoint` / `truncate_to_checkpoint_depth` now truncate shards and checkpoints unconditionally, so the boundary shard being absent from the store can no longer leave the cap, shards, and checkpoints mutually inconsistent.

The first commit adds regression tests (red at that commit); the second contains the fix. One of the tests reproduces the wallet-shaped failure entirely through the public API: append leaves, insert a batch-boundary frontier, truncate to an earlier checkpoint, then insert a frontier carrying divergent replacement data — which previously failed with `Insert(Conflict(..))`.

Also validated against librustzcash by path-patching this branch into its workspace: a wallet-level test that re-mines a transaction on a divergent chain after `rewind_to_chain_state` fails against shardtree 0.7.0 with `PutBlocksCommitmentTree { error: Insert(Conflict(..)) }` whenever earlier scan batches had written frontier ommers above the rewind target, and passes with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
